### PR TITLE
fixes mri throwing uninitialized constant SocketConnectionHandler::Query...

### DIFF
--- a/lib/volt/server/socket_connection_handler.rb
+++ b/lib/volt/server/socket_connection_handler.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'sockjs/session'
+require File.join(File.dirname(__FILE__), "../../../app/volt/tasks/query_tasks")
 
 class SocketConnectionHandler < SockJS::Session
   # Create one instance of the dispatcher


### PR DESCRIPTION
...Tasks error

fixes: https://gist.github.com/cj/79355c7a0248fff66ac0
