### PR TITLE
Correct typo "validtions" -> "validations"

### DIFF
--- a/lib/volt/models/validations.rb
+++ b/lib/volt/models/validations.rb
@@ -73,7 +73,7 @@ module Validations
           if klass
             validate_with(merge, klass, field_name, args)
           else
-            raise "validtion type #{validation} is not specified."
+            raise "validation type #{validation} is not specified."
           end
         end
       end


### PR DESCRIPTION
Just starting to play around with volt, so only contributing a typo fix so far. :)
