### PR TITLE
Updated Readme to correct typo in method name

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -520,7 +520,7 @@ A controller can be any class in Volt, however it is common to have that class i
     end
 ```
 
-2. Calling `self.method=` in a method:
+2. Calling `self.model=` in a method:
 
 ```ruby
     class TodosController < ModelController


### PR DESCRIPTION
I noticed the text didn't match the example, so I updated it.
