### PR TITLE
Added support for URI mongo configure via settings Volt.config.db_uri

### DIFF
--- a/lib/volt/data_stores/mongo_driver.rb
+++ b/lib/volt/data_stores/mongo_driver.rb
@@ -4,9 +4,13 @@ module Volt
   class DataStore
     class MongoDriver
       def self.fetch
-        @@mongo_db ||= Mongo::MongoClient.new(Volt.config.db_host, Volt.config.db_path)
-        @@db ||= @@mongo_db.db(Volt.config.db_name)
-
+        if Volt.config.db_uri.present?
+          @@mongo_db ||= Mongo::MongoClient.from_uri(Volt.config.db_uri)
+          @@db ||= @@mongo_db.db(Volt.config.db_uri.split('/').last || Volt.config.db_name)
+        else
+          @@mongo_db ||= Mongo::MongoClient.new(Volt.config.db_host, Volt.config.db_path)
+          @@db ||= @@mongo_db.db(Volt.config.db_name)
+        end
         @@db
       end
     end


### PR DESCRIPTION
Takes a new param for config to allow to create MongoClient by mongo URI instead of separate params.
Pretty useful for cloud services like MongoHQ/Heroku.
