### PR TITLE
Making Thin startup win compatible

### DIFF
--- a/lib/volt/cli.rb
+++ b/lib/volt/cli.rb
@@ -60,7 +60,7 @@ module Volt
       else
         ENV['SERVER'] = 'true'
         args          = ['start', '--threaded', '--max-persistent-conns', '300', '--max-conns', '400']
-
+        args.concat ['--max-conns', '400'] unless Gem.win_platform?
         if options[:port]
           args += ['-p', options[:port].to_s]
         end


### PR DESCRIPTION
---max--conns isn't compatible with Windows in Thin. Using `Gem.win_platform?` To detect windows and avoid --max-conns if necessary. I figured using the Gem library was okay since Volt also has a bundler dependency, which depends on, and expects gems. It was the most reliable way I could think of to get Windows detection accurately and easily.
