### PR TITLE
Ensure controller is available in all sections

### DIFF
--- a/lib/volt/page/bindings/template_binding.rb
+++ b/lib/volt/page/bindings/template_binding.rb
@@ -83,15 +83,9 @@ module Volt
         end
 
         path = full_path.join('/')
-        if check_for_template?(path)
-          controller = nil
 
-          # Don't return a controller if we are just getting another section
-          # from the same controller
-          if path_position >= 1
-            # Lookup the controller
-            controller = [full_path[0], full_path[1] + '_controller', full_path[2]]
-          end
+        if check_for_template?(path)
+          controller = [full_path[0], full_path[1] + '_controller', full_path[2]]
           return path, controller
         end
       end

--- a/spec/page/bindings/template_binding_spec.rb
+++ b/spec/page/bindings/template_binding_spec.rb
@@ -50,7 +50,7 @@ describe Volt::TemplateBinding do
 
     path, result = @template_binding.path_for_template('comments/new/errors')
     expect(path).to eq('main/comments/new/errors')
-    expect(result).to eq(nil)
+    expect(result).to eq(%w(main comments_controller new))
   end
 
   it 'should handle a tripple lookup to controllers' do


### PR DESCRIPTION
In the  `<:Body>` section, context was `MainController`
In other sections in the same file like `<:Nav>` the context was incorrectly `Volt::ModelController`

This change seems to create the desired behavior for me... but I haven't fully wrapped my head around all this yet so let me know if I'm missing something.
