### PR TITLE
Add a generic format validator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ group :development do
   # For testing the kitchen sink app
   # Twitter bootstrap
   gem 'volt-bootstrap'
-  gem 'byebug'
 
   # Simple theme for bootstrap, remove to theme yourself.
   gem 'volt-bootstrap-jumbotron-theme'
@@ -22,5 +21,6 @@ group :development do
 end
 
 group :development, :test do
+  gem 'pry-byebug', '~> 2.0.0'
   gem 'bson_ext'
 end

--- a/lib/volt/models/validations.rb
+++ b/lib/volt/models/validations.rb
@@ -1,5 +1,6 @@
 # require 'volt/models/validations/errors'
 require 'volt/models/validators/email_validator'
+require 'volt/models/validators/format_validator'
 require 'volt/models/validators/length_validator'
 require 'volt/models/validators/numericality_validator'
 require 'volt/models/validators/phone_number_validator'

--- a/lib/volt/models/validators/email_validator.rb
+++ b/lib/volt/models/validators/email_validator.rb
@@ -1,40 +1,19 @@
 module Volt
   class EmailValidator
-    DEFAULT_REGEX = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i
-    ERROR_MESSAGE = 'must be an email address'
+    DEFAULT_OPTIONS = {
+      with: /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i,
+      message: 'must be an email address'
+    }
 
     def self.validate(model, old_model, field_name, options)
       new(model, field_name, options).errors
     end
 
-    def initialize(model, field_name, options)
-      @value = model.read_attribute field_name
+    def self.new(model, field_name, options)
+      options = DEFAULT_OPTIONS if options == true
+      options = DEFAULT_OPTIONS.merge options
 
-      case options
-      when Hash, true, false
-        configure options
-      else
-        fail 'arguments can only be a Boolean or a Hash'
-      end
-    end
-
-    def valid?
-      return false unless @value.is_a? String
-
-      !!@value.match(@custom_regex || DEFAULT_REGEX)
-    end
-
-    def errors
-      valid? ? {} : { email: [@custom_message || ERROR_MESSAGE] }
-    end
-
-    private
-
-    def configure(options)
-      return unless options.is_a? Hash
-
-      @custom_message = options.fetch(:error_message) { nil }
-      @custom_regex = options.fetch(:with) { nil }
+      FormatValidator.new(model, field_name).apply options
     end
   end
 end

--- a/lib/volt/models/validators/format_validator.rb
+++ b/lib/volt/models/validators/format_validator.rb
@@ -1,0 +1,114 @@
+module Volt
+  class FormatValidator
+    # Creates a new instance with the provided options and returns it's errors
+    #
+    # @note the second param +old_model+ is unused and will soon be removed,
+    #   you can pass nil in the mean time
+    #
+    # @example
+    #   options = { with: /.+@.+/, message: 'must include an @ symobl' }
+    #
+    #   FormatValidator.validate(user, nil, 'email', options)
+    #
+    # @example
+    #   numbers_only = /^\d+$/
+    #   sum_equals_ten = ->(s) { s.chars.map(&:to_i).reduce(:+) == 10 }
+    #
+    #   options = [
+    #     { with: numbers_only, message: 'must include only numbers' },
+    #     { with: sum_equals_ten, message: 'must add up to 10' }
+    #   ]
+    #
+    #   FormatValidator.validate(user, nil, 'email', options)
+    #
+    # @param model [Volt::Model] the model being validated
+    # @param old_model [NilClass] no longer used, will be removed
+    # @param field_name [String] the name of the field being validated
+    #
+    # @param options (see #apply)
+    # @option options (see #apply)
+    #
+    # @return (see #errors)
+    def self.validate(model, old_model, field_name, options)
+      new(model, field_name).apply(options).errors
+    end
+
+    # @param model [Volt::Model] the model being validated
+    # @param field_name [String] the name of the field being validated
+    def initialize(model, field_name)
+      @name = field_name
+      @value = model.read_attribute field_name
+      @criteria = []
+    end
+
+    # Applies criteria to the validator in a variety of forms
+    #
+    # @see .validate param examples
+    # @param options [Hash, Array<Hash>] criteria and related error messages
+    #
+    # @option options [Regexp, Proc] :with criterion for validation
+    # @option options [String] :message to display if criterion not met
+    #   - will be appended to the field name
+    #   - should start with something like:
+    #     - +"must include..."+
+    #     - +"should end with..."+
+    #     - +"is invalid because..."+
+    #
+    # @return [self] returns itself for chaining
+    def apply(options)
+      return apply_list options if options.is_a? Array
+      with options[:with], options[:message]
+      self
+    end
+
+    # Returns the first of the validation errors or an empty hash
+    #
+    # @return [Hash] hash of validation errors for the field
+    #   - +{}+ if there are no errors
+    #   - +{ field_name: [messages] }+ if there are errors
+    def errors
+      valid? ? {} : { @name => error_messages }
+    end
+
+    # Returns an array of validation error messages
+    # @return [Array<String>]
+    def error_messages
+      @criteria.reduce([]) do |e, c|
+        test(c[:criterion]) ? e : e << c[:message]
+      end
+    end
+
+    # Returns true or false depending on if the model passes all its criteria
+    # @return [Boolean]
+    def valid?
+      error_messages.empty?
+    end
+
+    # Adds a criterion and error message
+    #
+    # @param criterion [Regexp, Proc] criterion for validation
+    # @param message [String] to display if criterion not met
+    #   - will be appended to the field name
+    #   - should start with something like:
+    #     - +"must include..."+
+    #     - +"should end with..."+
+    #     - +"is invalid because..."+
+    #
+    # @return (see #apply)
+    def with(criterion, message)
+      @criteria << { criterion: criterion, message: message }
+      self
+    end
+
+    private
+
+    def apply_list(array)
+      array.each { |options| apply options }
+      self
+    end
+
+    def test(criterion)
+      !!(criterion.try(:call, @value) || criterion.try(:match, @value))
+    end
+  end
+end

--- a/lib/volt/models/validators/format_validator.rb
+++ b/lib/volt/models/validators/format_validator.rb
@@ -108,6 +108,8 @@ module Volt
     end
 
     def test(criterion)
+      return false unless @value.respond_to? :match
+
       !!(criterion.try(:call, @value) || criterion.try(:match, @value))
     end
   end

--- a/lib/volt/models/validators/phone_number_validator.rb
+++ b/lib/volt/models/validators/phone_number_validator.rb
@@ -1,40 +1,19 @@
 module Volt
   class PhoneNumberValidator
-    DEFAULT_REGEX = /^(\+?\d{1,2}[\.\-\ ]?\d{3}|\(\d{3}\)|\d{3})[\.\-\ ]?\d{3,4}[\.\-\ ]?\d{4}$/
-    ERROR_MESSAGE = 'must be a phone number with area or country code'
+    DEFAULT_OPTIONS = {
+      with: /^(\+?\d{1,2}[\.\-\ ]?\d{3}|\(\d{3}\)|\d{3})[\.\-\ ]?\d{3,4}[\.\-\ ]?\d{4}$/,
+      message: 'must be a phone number with area or country code'
+    }
 
     def self.validate(model, old_model, field_name, options)
       new(model, field_name, options).errors
     end
 
-    def initialize(model, field_name, options)
-      @value = model.read_attribute field_name
+    def self.new(model, field_name, options)
+      options = DEFAULT_OPTIONS if options == true
+      options = DEFAULT_OPTIONS.merge options
 
-      case options
-      when Hash, true, false
-        configure options
-      else
-        fail 'arguments can only be a Boolean or a Hash'
-      end
-    end
-
-    def valid?
-      return false unless @value.is_a? String
-
-      !!@value.match(@custom_regex || DEFAULT_REGEX)
-    end
-
-    def errors
-      valid? ? {} : { phone_number: [@custom_message || ERROR_MESSAGE] }
-    end
-
-    private
-
-    def configure(options)
-      return unless options.is_a? Hash
-
-      @custom_message = options.fetch(:error_message) { nil }
-      @custom_regex = options.fetch(:with) { nil }
+      FormatValidator.new(model, field_name).apply options
     end
   end
 end

--- a/lib/volt/spec/setup.rb
+++ b/lib/volt/spec/setup.rb
@@ -9,6 +9,7 @@ module Volt
         ENV['VOLT_ENV'] = 'test'
 
         require 'volt/boot'
+        require 'pry-byebug'
 
         # Require in app
         Volt.boot(app_path)

--- a/spec/apps/kitchen_sink/Gemfile
+++ b/spec/apps/kitchen_sink/Gemfile
@@ -10,8 +10,8 @@ gem 'volt-bootstrap'
 # Simple theme for bootstrap, remove to theme yourself.
 gem 'volt-bootstrap-jumbotron-theme'
 
-gem 'volt-fields', path: '/Users/ryanstout/Sites/volt/apps/volt-fields'
-gem 'volt-user-templates', path: '/Users/ryanstout/Sites/volt/apps/volt-user-templates'
+gem 'volt-fields'
+gem 'volt-user-templates'
 
 # Server for MRI
 platform :mri do

--- a/spec/models/validations_spec.rb
+++ b/spec/models/validations_spec.rb
@@ -1,17 +1,22 @@
 require 'spec_helper'
 
-class TestModel < Volt::Model
-  validate :count, numericality: { min: 5, max: 10 }
-  validate :description, length: { message: 'needs to be longer', length: 50 }
-  validate :email, email: true
-  validate :name, length: 4
-  validate :phone_number, phone_number: true
-  validate :username, presence: true
-end
-
 describe Volt::Model do
-  it 'should validate the name' do
-    expect(TestModel.new.errors).to eq(
+  let(:model) { test_model_class.new }
+
+  let(:test_model_class) do
+    Class.new(Volt::Model) do
+      validate :count, numericality: { min: 5, max: 10 }
+      validate :description, length: { message: 'needs to be longer',
+                                       length: 50 }
+      validate :email, email: true
+      validate :name, length: 4
+      validate :phone_number, phone_number: true
+      validate :username, presence: true
+    end
+  end
+
+  it 'should return errors for all failed validations' do
+    expect(model.errors).to eq(
       count: ['must be a number'],
       description: ['needs to be longer'],
       email: ['must be an email address'],
@@ -21,23 +26,7 @@ describe Volt::Model do
     )
   end
 
-  it 'should show marked validations once they are marked' do
-    model = TestModel.new
-
-    expect(model.marked_errors).to eq({})
-
-    model.mark_field!(:name)
-
-    expect(model.marked_errors).to eq(
-      name: ['must be at least 4 characters']
-    )
-  end
-
   it 'should show all fields in marked errors once saved' do
-    model = TestModel.new
-
-    expect(model.marked_errors).to eq({})
-
     model.save!
 
     expect(model.marked_errors.keys).to eq(
@@ -45,73 +34,43 @@ describe Volt::Model do
     )
   end
 
-  describe 'length' do
-    it 'should allow custom errors on length' do
-      model = TestModel.new
-
-      expect(model.marked_errors).to eq({})
-
-      model.mark_field!(:description)
-
-      expect(model.marked_errors).to eq(
-        description: ['needs to be longer']
-      )
+  describe 'builtin validations' do
+    shared_examples_for 'a built in validation' do |field, message|
+      specify do
+        expect { model.mark_field! field }
+          .to change { model.marked_errors }
+          .from({}).to({ field => [message ] })
+      end
     end
-  end
 
-  describe 'presence' do
-    it 'should validate presence' do
-      model = TestModel.new
-
-      expect(model.marked_errors).to eq({})
-
-      model.mark_field!(:username)
-
-      expect(model.marked_errors).to eq(
-        username: ['must be specified']
-      )
+    describe 'numericality' do
+      message = 'must be a number'
+      it_should_behave_like 'a built in validation', :count, message
     end
-  end
 
-  describe 'numericality' do
-    it 'should validate numericality' do
-      model = TestModel.new
-
-      expect(model.marked_errors).to eq({})
-
-      model.mark_field!(:count)
-
-      expect(model.marked_errors).to eq(
-        count: ['must be a number']
-      )
+    describe 'length' do
+      message = 'needs to be longer'
+      it_should_behave_like 'a built in validation', :description, message
     end
-  end
 
-  describe 'email' do
-    it 'should validate email' do
-      model = TestModel.new
-
-      expect(model.marked_errors).to eq({})
-
-      model.mark_field!(:email)
-
-      expect(model.marked_errors).to eq(
-        email: ['must be an email address']
-      )
+    describe 'email' do
+      message = 'must be an email address'
+      it_should_behave_like 'a built in validation', :email, message
     end
-  end
 
-  describe 'phone_number' do
-    it 'should validate phone number' do
-      model = TestModel.new
+    describe 'name' do
+      message = 'must be at least 4 characters'
+      it_should_behave_like 'a built in validation', :name, message
+    end
 
-      expect(model.marked_errors).to eq({})
+    describe 'phone_number' do
+      message = 'must be a phone number with area or country code'
+      it_should_behave_like 'a built in validation', :phone_number, message
+    end
 
-      model.mark_field!(:phone_number)
-
-      expect(model.marked_errors).to eq(
-        phone_number: ['must be a phone number with area or country code']
-      )
+    describe 'presence' do
+      message = 'must be specified'
+      it_should_behave_like 'a built in validation', :username, message
     end
   end
 end

--- a/spec/models/validations_spec.rb
+++ b/spec/models/validations_spec.rb
@@ -73,4 +73,36 @@ describe Volt::Model do
       it_should_behave_like 'a built in validation', :username, message
     end
   end
+
+  describe 'validators with multiple criteria' do
+    let(:regex_message) { 'regex failed' }
+    let(:proc_message) { 'proc failed' }
+
+    let(:test_model_class) do
+      Class.new(Volt::Model) do
+        validate :special_field, format: [
+          { with: /regex/, message: 'regex failed' },
+          { with: ->(x) {x == false}, message: 'proc failed' }
+        ]
+      end
+    end
+
+    context 'when multiple fail' do
+      before { model._special_field = 'nope' }
+
+      it 'returns an array of errors' do
+        expect(model.errors).to eq({
+          special_field: [ regex_message, proc_message ]
+        })
+      end
+    end
+
+    context 'when one fails' do
+      before { model._special_field = 'regex' }
+
+      it 'returns an array with a single error' do
+        expect(model.errors).to eq({ special_field: [ proc_message ] })
+      end
+    end
+  end
 end

--- a/spec/models/validators/email_validator_spec.rb
+++ b/spec/models/validators/email_validator_spec.rb
@@ -105,7 +105,7 @@ describe Volt::EmailValidator do
     end
 
     context 'when provided a custom error message' do
-      let(:options) { { error_message: custom_message } }
+      let(:options) { { message: custom_message } }
       let(:custom_message) { 'this is a custom message' }
 
       context 'and the email is invalid' do

--- a/spec/models/validators/format_validator_spec.rb
+++ b/spec/models/validators/format_validator_spec.rb
@@ -1,0 +1,144 @@
+require 'spec_helper'
+
+describe Volt::FormatValidator do
+  subject { described_class.new(*init_params) }
+
+  let(:init_params) { [ model, field_name ] }
+  let(:validate_params) { [ model, nil, field_name, options ] }
+
+  let(:model) { Volt::Model.new field: field_content }
+  let(:field_name) { :field }
+  let(:options) { regex_opts }
+
+  let(:regex) { /^valid/ }
+  let(:proc_regex) { /^valid/ }
+  let(:test_proc) { ->(content) { proc_regex.match content } }
+
+  let(:proc_opts) { { with: test_proc, message: proc_message } }
+  let(:regex_opts) { { with: regex, message: regex_message } }
+
+  let(:proc_message) { 'proc is invalid' }
+  let(:regex_message) { 'regex is invalid' }
+
+  let(:field_content) { valid_content }
+  let(:invalid_content) { 'invalid_content' }
+  let(:valid_content) { 'valid_content' }
+
+  let(:validate) { described_class.validate(*validate_params) }
+
+  before do
+    allow(described_class).to receive(:new).and_return subject
+  end
+
+  context 'when no criteria is provided' do
+    before { validate }
+
+    it 'should have no errors' do
+      expect(subject.errors).to eq({})
+    end
+
+    specify { expect(subject).to be_valid }
+  end
+
+  context 'when the only criterion is a regex' do
+    let(:options) { regex_opts }
+
+    before { validate }
+
+    context 'and the field matches' do
+      let(:field_content) { valid_content }
+
+      it 'should have no errors' do
+        expect(subject.errors).to eq({})
+      end
+
+      specify { expect(subject).to be_valid }
+    end
+
+    context 'and the field does not match' do
+      let(:field_content) { invalid_content }
+
+      it 'should report the related error message' do
+        expect(subject.errors).to eq field_name => [regex_message]
+      end
+
+      specify { expect(subject).to_not be_valid }
+    end
+  end
+
+  context 'when the only criterion is a block' do
+    let(:options) { proc_opts }
+
+    before { validate }
+
+    context 'and the field passes the block' do
+      let(:field_content) { valid_content }
+
+      it 'should have no errors' do
+        expect(subject.errors).to eq({})
+      end
+
+      specify { expect(subject).to be_valid }
+    end
+
+    context 'and the field fails the block' do
+      let(:field_content) { invalid_content }
+
+      it 'should report the related error message' do
+        expect(subject.errors).to eq field_name => [proc_message]
+      end
+
+      specify { expect(subject).to_not be_valid }
+    end
+  end
+
+  context 'when there is both regex and block criteria' do
+    let(:options) { [ regex_opts, proc_opts ] }
+
+    before { validate }
+
+    context 'and the field passes all criteria' do
+      let(:field_content) { valid_content }
+
+      it 'should have no errors' do
+        expect(subject.errors).to eq({})
+      end
+
+      specify { expect(subject).to be_valid }
+    end
+
+    context 'and the field fails the regex' do
+      let(:regex) { /^invalid/ }
+
+      it 'should report the related error message' do
+        expect(subject.errors).to eq field_name => [regex_message]
+      end
+
+      specify { expect(subject).to_not be_valid }
+    end
+
+    context 'and the field fails the block' do
+      let(:proc_regex) { /^invalid/ }
+
+      it 'should report the related error message' do
+        expect(subject.errors).to eq field_name => [proc_message]
+      end
+
+      specify { expect(subject).to_not be_valid }
+    end
+
+    context 'and the field fails both the regex and the block' do
+      let(:field_content) { invalid_content }
+
+      it 'should report the regex error message' do
+        expect(subject.errors[field_name]).to include regex_message
+      end
+
+      it 'should report the proc error message' do
+        expect(subject.errors[field_name]).to include proc_message
+      end
+
+      specify { expect(subject).to_not be_valid }
+    end
+  end
+end

--- a/spec/models/validators/phone_number_validator_spec.rb
+++ b/spec/models/validators/phone_number_validator_spec.rb
@@ -131,7 +131,7 @@ describe Volt::PhoneNumberValidator do
     end
 
     context 'when provided a custom error message' do
-      let(:options) { { error_message: custom_message } }
+      let(:options) { { message: custom_message } }
       let(:custom_message) { 'this is a custom message' }
 
       context 'and the phone number is invalid' do

--- a/volt.gemspec
+++ b/volt.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'thor', '~> 0.19.0'
-  spec.add_dependency 'pry', '~> 0.9.12.0'
+  spec.add_dependency 'pry', '~> 0.10.0'
   spec.add_dependency 'rack', '~> 1.5.0'
   spec.add_dependency 'sprockets-sass', '~> 1.0.0'
   spec.add_dependency 'sass', '~> 3.2.5'


### PR DESCRIPTION
- will allow users easily create custom content validations
- should dry up other validations by providing a reusable base