### PR TITLE
Fix regex in String#blank?

### DIFF
--- a/lib/volt/extra_core/blank.rb
+++ b/lib/volt/extra_core/blank.rb
@@ -70,9 +70,7 @@ class String
   #   '　'.blank?               # => true
   #   ' something here '.blank? # => false
   def blank?
-    # self !~ /[^[:space:]]/
-    # TODO: Opal fails with the previous regex
-    strip == ''
+    self !~ /\S/
   end
 end
 


### PR DESCRIPTION
The reason for previous Opal failure is that `[:space:]` doesn't exist in Javascript regex syntax.