### PR TITLE
Validator cleanup

### DIFF
--- a/lib/volt/models/validations.rb
+++ b/lib/volt/models/validations.rb
@@ -1,6 +1,6 @@
 require 'volt/models/errors'
-require 'volt/models/validators/email_validator'
 require 'volt/models/validators/format_validator'
+require 'volt/models/validators/email_validator'
 require 'volt/models/validators/length_validator'
 require 'volt/models/validators/numericality_validator'
 require 'volt/models/validators/phone_number_validator'

--- a/lib/volt/models/validators/email_validator.rb
+++ b/lib/volt/models/validators/email_validator.rb
@@ -1,19 +1,14 @@
 module Volt
-  class EmailValidator
+  class EmailValidator < FormatValidator
     DEFAULT_OPTIONS = {
       with: /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i,
       message: 'must be an email address'
     }
 
-    def self.validate(model, field_name, options)
-      new(model, field_name, options).errors
-    end
+    private
 
-    def self.new(model, field_name, options)
-      options = DEFAULT_OPTIONS if options == true
-      options = DEFAULT_OPTIONS.merge options
-
-      FormatValidator.new(model, field_name).apply options
+    def default_options
+      DEFAULT_OPTIONS
     end
   end
 end

--- a/lib/volt/models/validators/format_validator.rb
+++ b/lib/volt/models/validators/format_validator.rb
@@ -7,7 +7,7 @@ module Volt
     # @example
     #   options = { with: /.+@.+/, message: 'must include an @ symobl' }
     #
-    #   FormatValidator.validate(user, nil, 'email', options)
+    #   FormatValidator.validate(user, 'email', options)
     #
     # @example
     #   numbers_only = /^\d+$/
@@ -18,7 +18,7 @@ module Volt
     #     { with: sum_equals_ten, message: 'must add up to 10' }
     #   ]
     #
-    #   FormatValidator.validate(user, nil, 'email', options)
+    #   FormatValidator.validate(user, 'email', options)
     #
     # @param model [Volt::Model] the model being validated
     # @param field_name [String] the name of the field being validated

--- a/lib/volt/models/validators/format_validator.rb
+++ b/lib/volt/models/validators/format_validator.rb
@@ -1,4 +1,6 @@
 module Volt
+  # Validates the format of a field against any number of block or regex
+  # criteria
   class FormatValidator
     # Creates a new instance with the provided options and returns it's errors
     #

--- a/lib/volt/models/validators/format_validator.rb
+++ b/lib/volt/models/validators/format_validator.rb
@@ -56,6 +56,18 @@ module Volt
     # @return [self] returns itself for chaining
     def apply(options)
       return apply_list options if options.is_a? Array
+
+      options = case options
+                when true
+                  default_options
+                when Hash
+                  if default_options.is_a? Hash
+                    default_options.merge options
+                  else
+                    options
+                  end
+                end
+
       with options[:with], options[:message]
       self
     end
@@ -104,6 +116,10 @@ module Volt
     def apply_list(array)
       array.each { |options| apply options }
       self
+    end
+
+    def default_options
+      {}
     end
 
     def test(criterion)

--- a/lib/volt/models/validators/phone_number_validator.rb
+++ b/lib/volt/models/validators/phone_number_validator.rb
@@ -1,19 +1,14 @@
 module Volt
-  class PhoneNumberValidator
+  class PhoneNumberValidator < FormatValidator
     DEFAULT_OPTIONS = {
       with: /^(\+?\d{1,2}[\.\-\ ]?\d{3}|\(\d{3}\)|\d{3})[\.\-\ ]?\d{3,4}[\.\-\ ]?\d{4}$/,
       message: 'must be a phone number with area or country code'
     }
 
-    def self.validate(model, field_name, options)
-      new(model, field_name, options).errors
-    end
+    private
 
-    def self.new(model, field_name, options)
-      options = DEFAULT_OPTIONS if options == true
-      options = DEFAULT_OPTIONS.merge options
-
-      FormatValidator.new(model, field_name).apply options
+    def default_options
+      DEFAULT_OPTIONS
     end
   end
 end

--- a/spec/models/validators/email_validator_spec.rb
+++ b/spec/models/validators/email_validator_spec.rb
@@ -1,120 +1,66 @@
 require 'spec_helper'
+require 'models/validators/shared_examples_for_validators'
 
 describe Volt::EmailValidator do
-  subject { Volt::EmailValidator.new(*params) }
-  let(:params) { [model, field_name, options] }
+  subject { described_class.new(*init_params) }
+  let(:init_params) { [model, field_name] }
 
   let(:model) { Volt::Model.new email: email }
   let(:field_name) { :email }
   let(:options) { true }
 
+  let(:email) { field_content }
+  let(:field_contet) { valid_email }
   let(:valid_email) { 'test@example.com' }
   let(:invalid_email) { 'test@example-com' }
-  let(:email) { valid_email }
 
-  describe '.validate' do
-    let(:result) { described_class.validate(*params) }
+  let(:validate) { described_class.validate(*params) }
+  let(:params) { [model, field_name, options] }
+  let(:message) { 'must be an email address' }
 
-    before do
-      allow(described_class).to receive(:new).and_return subject
-      allow(subject).to receive(:errors).and_call_original
+  it_behaves_like 'a format validator'
 
-      result
-    end
-
-    it 'initializes an email validator with the provided arguments' do
-      expect(described_class).to have_received(:new).with(*params)
-    end
-
-    it 'calls errors on the email validator' do
-      expect(subject).to have_received :errors
-    end
-
-    it 'returns the result of calling errors on the validator' do
-      expect(subject.errors).to eq result
-    end
+  before do
+    allow(described_class).to receive(:new).and_return subject
   end
 
-  describe '#valid?' do
-    context 'when using the default regex' do
-      let(:options) { true }
+  context 'when the email is valid' do
+    let(:email) { valid_email }
 
-      context 'when the email is valid' do
-        let(:email) { valid_email }
+    specify { expect(validate).to eq({}) }
 
-        specify { expect(subject.valid?).to eq true }
-      end
+    context 'and when no override criteria is provided' do
+      before { validate }
 
-      context 'when the email is missing a TLD' do
-        let(:email) { 'test@example' }
-
-        specify { expect(subject.valid?).to eq false }
-      end
-
-      context 'when the email TLD is only one character' do
-        let(:email) { 'test@example.c' }
-
-        specify { expect(subject.valid?).to eq false }
-      end
-
-      context 'when the email is missing an username' do
-        let(:email) { '@example.com' }
-
-        specify { expect(subject.valid?).to eq false }
-      end
-
-      context 'when the email is missing the @ symbol' do
-        let(:email) { 'test.example.com' }
-
-        specify { expect(subject.valid?).to eq false }
-      end
-    end
-
-    context 'when using a custom regex' do
-      let(:options) { { with: /.+\@.+/ } }
-
-      context 'and the email qualifies' do
-        let(:email) { 'test@example' }
-
-        specify { expect(subject.valid?).to eq true }
-      end
-
-      context 'and the email does not qualify' do
-        let(:email) { 'test$example' }
-
-        specify { expect(subject.valid?).to eq false }
-      end
-    end
-  end
-
-  describe '#errors' do
-    context 'when the model has a valid email' do
-      let(:email) { valid_email }
-
-      it 'returns an empty error hash' do
+      it 'should have no errors' do
         expect(subject.errors).to eq({})
       end
+
+      specify { expect(subject).to be_valid }
     end
+  end
 
-    context 'when the model has an invalid email' do
-      let(:email) { invalid_email }
+  context 'when the email is missing a TLD' do
+    let(:email) { 'test@example' }
 
-      it 'returns an array of errors for email' do
-        expect(subject.errors).to eq(email: ['must be an email address'])
-      end
-    end
+    specify { expect(validate).to eq(field_name => [message]) }
+  end
 
-    context 'when provided a custom error message' do
-      let(:options) { { message: custom_message } }
-      let(:custom_message) { 'this is a custom message' }
+  context 'when the email TLD is only one character' do
+    let(:email) { 'test@example.c' }
 
-      context 'and the email is invalid' do
-        let(:email) { invalid_email }
+    specify { expect(validate).to eq(field_name => [message]) }
+  end
 
-        it 'returns errors with the custom message' do
-          expect(subject.errors).to eq(email: [custom_message])
-        end
-      end
-    end
+  context 'when the email is missing an username' do
+    let(:email) { '@example.com' }
+
+    specify { expect(validate).to eq(field_name => [message]) }
+  end
+
+  context 'when the email is missing the @ symbol' do
+    let(:email) { 'test.example.com' }
+
+    specify { expect(validate).to eq(field_name => [message]) }
   end
 end

--- a/spec/models/validators/format_validator_spec.rb
+++ b/spec/models/validators/format_validator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'models/validators/shared_examples_for_validators'
 
 describe Volt::FormatValidator do
   subject { described_class.new(*init_params) }
@@ -26,9 +27,7 @@ describe Volt::FormatValidator do
 
   let(:validate) { described_class.validate(*validate_params) }
 
-  before do
-    allow(described_class).to receive(:new).and_return subject
-  end
+  it_behaves_like 'a format validator'
 
   context 'when no criteria is provided' do
     before { validate }
@@ -38,107 +37,5 @@ describe Volt::FormatValidator do
     end
 
     specify { expect(subject).to be_valid }
-  end
-
-  context 'when the only criterion is a regex' do
-    let(:options) { regex_opts }
-
-    before { validate }
-
-    context 'and the field matches' do
-      let(:field_content) { valid_content }
-
-      it 'should have no errors' do
-        expect(subject.errors).to eq({})
-      end
-
-      specify { expect(subject).to be_valid }
-    end
-
-    context 'and the field does not match' do
-      let(:field_content) { invalid_content }
-
-      it 'should report the related error message' do
-        expect(subject.errors).to eq field_name => [regex_message]
-      end
-
-      specify { expect(subject).to_not be_valid }
-    end
-  end
-
-  context 'when the only criterion is a block' do
-    let(:options) { proc_opts }
-
-    before { validate }
-
-    context 'and the field passes the block' do
-      let(:field_content) { valid_content }
-
-      it 'should have no errors' do
-        expect(subject.errors).to eq({})
-      end
-
-      specify { expect(subject).to be_valid }
-    end
-
-    context 'and the field fails the block' do
-      let(:field_content) { invalid_content }
-
-      it 'should report the related error message' do
-        expect(subject.errors).to eq field_name => [proc_message]
-      end
-
-      specify { expect(subject).to_not be_valid }
-    end
-  end
-
-  context 'when there is both regex and block criteria' do
-    let(:options) { [ regex_opts, proc_opts ] }
-
-    before { validate }
-
-    context 'and the field passes all criteria' do
-      let(:field_content) { valid_content }
-
-      it 'should have no errors' do
-        expect(subject.errors).to eq({})
-      end
-
-      specify { expect(subject).to be_valid }
-    end
-
-    context 'and the field fails the regex' do
-      let(:regex) { /^invalid/ }
-
-      it 'should report the related error message' do
-        expect(subject.errors).to eq field_name => [regex_message]
-      end
-
-      specify { expect(subject).to_not be_valid }
-    end
-
-    context 'and the field fails the block' do
-      let(:proc_regex) { /^invalid/ }
-
-      it 'should report the related error message' do
-        expect(subject.errors).to eq field_name => [proc_message]
-      end
-
-      specify { expect(subject).to_not be_valid }
-    end
-
-    context 'and the field fails both the regex and the block' do
-      let(:field_content) { invalid_content }
-
-      it 'should report the regex error message' do
-        expect(subject.errors[field_name]).to include regex_message
-      end
-
-      it 'should report the proc error message' do
-        expect(subject.errors[field_name]).to include proc_message
-      end
-
-      specify { expect(subject).to_not be_valid }
-    end
   end
 end

--- a/spec/models/validators/phone_number_validator_spec.rb
+++ b/spec/models/validators/phone_number_validator_spec.rb
@@ -1,146 +1,103 @@
 require 'spec_helper'
+require 'models/validators/shared_examples_for_validators'
 
 describe Volt::PhoneNumberValidator do
-  subject { Volt::PhoneNumberValidator.new(*params) }
-  let(:params) { [model, field_name, options] }
+  subject { described_class.new(*init_params) }
+  let(:init_params) { [model, field_name] }
 
   let(:model) { Volt::Model.new phone_number: phone_number }
   let(:field_name) { :phone_number }
   let(:options) { true }
 
+  let(:phone_number) { field_content }
+  let(:field_contet) { valid_us_number }
   let(:valid_us_number) { '(123)-123-1234' }
   let(:valid_intl_number) { '+12 123 123 1234' }
   let(:invalid_number) { '1234-123-123456' }
-  let(:phone_number) { valid_us_number }
 
-  describe '.validate' do
-    let(:result) { described_class.validate(*params) }
+  let(:validate) { described_class.validate(*params) }
+  let(:params) { [model, field_name, options] }
+  let(:message) { 'must be a phone number with area or country code' }
 
-    before do
-      allow(described_class).to receive(:new).and_return subject
-      allow(subject).to receive(:errors).and_call_original
+  it_behaves_like 'a format validator'
 
-      result
-    end
-
-    it 'initializes a phone number validator with the provided arguments' do
-      expect(described_class).to have_received(:new).with(*params)
-    end
-
-    it 'calls errors on the phone number validator' do
-      expect(subject).to have_received :errors
-    end
-
-    it 'returns the result of calling errors on the validator' do
-      expect(subject.errors).to eq result
-    end
+  before do
+    allow(described_class).to receive(:new).and_return subject
   end
 
-  describe '#valid?' do
-    context 'when using the default regex' do
-      let(:options) { true }
+  context 'when the phone number is a valid US number' do
+    let(:phone_number) { valid_us_number }
 
-      context 'when the phone number is a valid US number' do
-        let(:phone_number) { valid_us_number }
+    specify { expect(validate).to eq({}) }
 
-        specify { expect(subject.valid?).to eq true }
-      end
+    context 'and when no override criteria is provided' do
+      before { validate }
 
-      context 'when the phone number is a valid international number' do
-        let(:phone_number) { valid_intl_number }
-
-        specify { expect(subject.valid?).to eq true }
-      end
-
-      context 'when the phone number uses dashes' do
-        let(:phone_number) { '123-123-1234' }
-
-        specify { expect(subject.valid?).to eq true }
-      end
-
-      context 'when the phone number uses periods' do
-        let(:phone_number) { '123.123.1234' }
-
-        specify { expect(subject.valid?).to eq true }
-      end
-
-      context 'when the phone number uses spaces' do
-        let(:phone_number) { '123 123 1234' }
-
-        specify { expect(subject.valid?).to eq true }
-      end
-
-      context 'when the phone number uses parentheses and a space' do
-        let(:phone_number) { '(123) 123.1234' }
-
-        specify { expect(subject.valid?).to eq true }
-      end
-
-      context 'when an international number uses a plus' do
-        let(:phone_number) { '+12 123 123 1234' }
-
-        specify { expect(subject.valid?).to eq true }
-      end
-
-      context 'when an international number does not use a plus' do
-        let(:phone_number) { '12 123 123 1234' }
-
-        specify { expect(subject.valid?).to eq true }
-      end
-
-      context 'when an international number is from the UK' do
-        let(:phone_number) { '+12 123 1234 1234' }
-
-        specify { expect(subject.valid?).to eq true }
-      end
-    end
-
-    context 'when using a custom regex' do
-      let(:options) { { with: /\d{10}/ } }
-
-      context 'and the phone number qualifies' do
-        let(:phone_number) { '1231231234' }
-
-        specify { expect(subject.valid?).to eq true }
-      end
-
-      context 'and the phone number does not qualify' do
-        let(:phone_number) { '123-123-1234' }
-
-        specify { expect(subject.valid?).to eq false }
-      end
-    end
-  end
-
-  describe '#errors' do
-    context 'when the model has a valid phone number' do
-      let(:phone_number) { valid_us_number }
-
-      it 'returns an empty error hash' do
+      it 'should have no errors' do
         expect(subject.errors).to eq({})
       end
-    end
 
-    context 'when the model has an invalid phone number' do
-      let(:phone_number) { invalid_number }
+      specify { expect(subject).to be_valid }
+    end
+  end
+
+  context 'when the model has an invalid phone number' do
+    let(:phone_number) { invalid_number }
+
+    context 'and when no override criteria is provided' do
+      before { validate }
 
       it 'returns an array of errors for phone number' do
-        expect(subject.errors).to eq(
-          phone_number: ['must be a phone number with area or country code'])
+        expect(subject.errors).to eq field_name => [message]
       end
     end
+  end
 
-    context 'when provided a custom error message' do
-      let(:options) { { message: custom_message } }
-      let(:custom_message) { 'this is a custom message' }
+  context 'when the phone number is a valid international number' do
+    let(:phone_number) { valid_intl_number }
 
-      context 'and the phone number is invalid' do
-        let(:phone_number) { invalid_number }
+    specify { expect(subject.valid?).to eq true }
+  end
 
-        it 'returns errors with the custom message' do
-          expect(subject.errors).to eq(phone_number: [custom_message])
-        end
-      end
-    end
+  context 'when the phone number uses dashes' do
+    let(:phone_number) { '123-123-1234' }
+
+    specify { expect(subject.valid?).to eq true }
+  end
+
+  context 'when the phone number uses periods' do
+    let(:phone_number) { '123.123.1234' }
+
+    specify { expect(subject.valid?).to eq true }
+  end
+
+  context 'when the phone number uses spaces' do
+    let(:phone_number) { '123 123 1234' }
+
+    specify { expect(subject.valid?).to eq true }
+  end
+
+  context 'when the phone number uses parentheses and a space' do
+    let(:phone_number) { '(123) 123.1234' }
+
+    specify { expect(subject.valid?).to eq true }
+  end
+
+  context 'when an international number uses a plus' do
+    let(:phone_number) { '+12 123 123 1234' }
+
+    specify { expect(subject.valid?).to eq true }
+  end
+
+  context 'when an international number does not use a plus' do
+    let(:phone_number) { '12 123 123 1234' }
+
+    specify { expect(subject.valid?).to eq true }
+  end
+
+  context 'when an international number is from the UK' do
+    let(:phone_number) { '+12 123 1234 1234' }
+
+    specify { expect(subject.valid?).to eq true }
   end
 end

--- a/spec/models/validators/shared_examples_for_validators.rb
+++ b/spec/models/validators/shared_examples_for_validators.rb
@@ -1,0 +1,123 @@
+require 'spec_helper'
+
+shared_examples_for 'a format validator' do
+  let(:regex) { /^valid/ }
+  let(:proc_regex) { /^valid/ }
+  let(:test_proc) { ->(content) { proc_regex.match content } }
+
+  let(:proc_opts) { { with: test_proc, message: proc_message } }
+  let(:regex_opts) { { with: regex, message: regex_message } }
+
+  let(:field_content) { valid_content }
+  let(:invalid_content) { 'invalid_content' }
+  let(:valid_content) { 'valid_content' }
+
+  let(:proc_message) { 'proc is invalid' }
+  let(:regex_message) { 'regex is invalid' }
+
+  before do
+    allow(described_class).to receive(:new).and_return subject
+  end
+
+  context 'when the only override criterion is a regex' do
+    let(:options) { regex_opts }
+
+    before { validate }
+
+    context 'and when the field matches' do
+      let(:field_content) { valid_content }
+
+      it 'should have no errors' do
+        expect(subject.errors).to eq({})
+      end
+
+      specify { expect(subject).to be_valid }
+    end
+
+    context 'and when the field does not match' do
+      let(:field_content) { invalid_content }
+
+      it 'should report the related error message' do
+        expect(subject.errors).to eq field_name => [regex_message]
+      end
+
+      specify { expect(subject).to_not be_valid }
+    end
+  end
+
+  context 'when the only override criterion is a block' do
+    let(:options) { proc_opts }
+
+    before { validate }
+
+    context 'and when the field passes the block' do
+      let(:field_content) { valid_content }
+
+      it 'should have no errors' do
+        expect(subject.errors).to eq({})
+      end
+
+      specify { expect(subject).to be_valid }
+    end
+
+    context 'and when the field fails the block' do
+      let(:field_content) { invalid_content }
+
+      it 'should report the related error message' do
+        expect(subject.errors).to eq field_name => [proc_message]
+      end
+
+      specify { expect(subject).to_not be_valid }
+    end
+  end
+
+  context 'when there is both regex and block criteria' do
+    let(:options) { [ regex_opts, proc_opts ] }
+
+    before { validate }
+
+    context 'and when the field passes all criteria' do
+      let(:field_content) { valid_content }
+
+      it 'should have no errors' do
+        expect(subject.errors).to eq({})
+      end
+
+      specify { expect(subject).to be_valid }
+    end
+
+    context 'and when the field fails the regex' do
+      let(:regex) { /^invalid/ }
+
+      it 'should report the related error message' do
+        expect(subject.errors).to eq field_name => [regex_message]
+      end
+
+      specify { expect(subject).to_not be_valid }
+    end
+
+    context 'and when the field fails the block' do
+      let(:proc_regex) { /^invalid/ }
+
+      it 'should report the related error message' do
+        expect(subject.errors).to eq field_name => [proc_message]
+      end
+
+      specify { expect(subject).to_not be_valid }
+    end
+
+    context 'and when the field fails both the regex and the block' do
+      let(:field_content) { invalid_content }
+
+      it 'should report the regex error message' do
+        expect(subject.errors[field_name]).to include regex_message
+      end
+
+      it 'should report the proc error message' do
+        expect(subject.errors[field_name]).to include proc_message
+      end
+
+      specify { expect(subject).to_not be_valid }
+    end
+  end
+end


### PR DESCRIPTION
Just finishing up the refactor from a while ago when I made the format validator class. This removes the need to override new on the email and phone number validators by making format validator their superclass. It also drys up the specs by extracting common ones to shared examples.