### PR TITLE
Fix adding non-volt gems to component paths

### DIFF
--- a/lib/volt/server/rack/component_paths.rb
+++ b/lib/volt/server/rack/component_paths.rb
@@ -16,7 +16,7 @@ module Volt
 
         # Gem folders with volt in them
         # TODO: we should probably qualify this a bit more
-        app_folders += Gem.loaded_specs.values.map(&:full_gem_path).reject { |g| g !~ /volt/ }.map { |f| f + '/app' }
+        app_folders += Gem.loaded_specs.values.reduce([]) { |paths, gem| paths << "#{gem.full_gem_path}/app" if gem.name =~ /volt/; paths }
 
         app_folders.uniq
       end

--- a/spec/server/rack/component_paths_spec.rb
+++ b/spec/server/rack/component_paths_spec.rb
@@ -24,5 +24,16 @@ if RUBY_PLATFORM != 'opal'
       main_path = @component_paths.component_paths('main').first
       expect(main_path).to match(/spec\/apps\/file_loading\/app\/main$/)
     end
+
+    it 'should not return paths to non-volt gems' do
+      Gem.loaded_specs['fake-gem'] = Gem::Specification.new do |s|
+        s.name = 'fake-gem'
+        s.version = Gem::Version.new('1.0')
+        s.full_gem_path = '/home/volt/projects/volt-app'
+      end
+      app_folders = @component_paths.app_folders { |f| f }
+      expect(app_folders).to_not include('/home/volt/projects/volt-app/app')
+      Gem.loaded_specs.delete 'fake-gem'
+    end
   end
 end


### PR DESCRIPTION
This fixes #120 `Unable to find component 'rspec-builder.rb'` error when gemset name is volt.