### PR TITLE
Fix logger spec for certain cases

### DIFF
--- a/spec/extra_core/logger_spec.rb
+++ b/spec/extra_core/logger_spec.rb
@@ -26,6 +26,8 @@ if RUBY_PLATFORM != 'opal'
     end
 
     describe 'when STDOUT is a TTY' do
+      before { allow(STDOUT).to receive(:tty?).and_return(true) }
+      
       it 'should return a blue class name' do
         expect(logger_with_opts.class_name).to eq("\e[1;34m#{class_name}\e[0;37m")
       end


### PR DESCRIPTION
It is possible to run tests while not actually being a TTY terminal (for example using backticks in Ruby). 

This change makes sure tests are running correctly by forcing STDOUT.tty? to return true even if we're running tests from terminal that is not actually TTY.