### PR TITLE
suppress the logging of plaintext passwords

### DIFF
--- a/lib/volt/extra_core/logger.rb
+++ b/lib/volt/extra_core/logger.rb
@@ -79,10 +79,14 @@ else
       def task_dispatch_message
         msg = "task #{class_name}##{method_name} in #{run_time}\n"
         if args.size > 0
-          arg_str = args.map {|v| v.inspect }.join(', ')
+          arg_str = parse_args(args)
           msg += "with args: #{arg_str}\n"
         end
         msg
+      end
+
+      def parse_args(args, filters = ['password'])
+        args.map { |arg| arg.inspect unless filters.include?(arg.to_s) }.compact!.join(', ')
       end
     end
 

--- a/spec/extra_core/logger_spec.rb
+++ b/spec/extra_core/logger_spec.rb
@@ -33,12 +33,6 @@ if RUBY_PLATFORM != 'opal'
       expect(logger_with_opts.args).to eq([5, :arg2])
     end
 
-    it 'should deny logging of password fields' do
-     
-      out = StringIO.new
-      $stdout = out
-    end
-
     describe 'when STDOUT is a TTY' do
       before { allow(STDOUT).to receive(:tty?).and_return(true) }
       

--- a/spec/extra_core/logger_spec.rb
+++ b/spec/extra_core/logger_spec.rb
@@ -4,6 +4,7 @@ if RUBY_PLATFORM != 'opal'
     let(:class_name)  { 'ClassName' }
     let(:method_name) { 'method_name' }
     let(:run_time)    { 50 }
+    let(:bad_args)    { ['1', 'password', '2'] }
 
     let(:logger) { Volt::VoltLogger.new }
 
@@ -21,8 +22,21 @@ if RUBY_PLATFORM != 'opal'
       logger.log(Logger::INFO, "message")
     end
 
+    it 'should not log password credentials' do
+        msg = "\n\n[INFO] task \e[1;34mClassName\e[0;37m#\e[0;32mmethod_name\e[0;37m in \e[0;32m50ms\e[0;37m\nwith args: \"1\", \"2\"\n\n"
+       expect(STDOUT).to receive(:write).with msg
+       logger.log_dispatch(class_name, method_name, run_time, bad_args)
+    end
+
+
     it 'should convert an array of arguments into a string' do
       expect(logger_with_opts.args).to eq([5, :arg2])
+    end
+
+    it 'should deny logging of password fields' do
+     
+      out = StringIO.new
+      $stdout = out
     end
 
     describe 'when STDOUT is a TTY' do

--- a/spec/extra_core/logger_spec.rb
+++ b/spec/extra_core/logger_spec.rb
@@ -23,7 +23,7 @@ if RUBY_PLATFORM != 'opal'
     end
 
     it 'should not log password credentials' do
-        msg = "\n\n[INFO] task \e[1;34mClassName\e[0;37m#\e[0;32mmethod_name\e[0;37m in \e[0;32m50ms\e[0;37m\nwith args: \"1\", \"2\"\n\n"
+       msg = "\n\n[INFO] task \e[1;34mClassName\e[0;37m#\e[0;32mmethod_name\e[0;37m in \e[0;32m50ms\e[0;37m\nwith args: \"1\", \"2\"\n\n"
        expect(STDOUT).to receive(:write).with msg
        logger.log_dispatch(class_name, method_name, run_time, bad_args)
     end


### PR DESCRIPTION
This is pretty simple. 

All I did was extract a `parse_args` private method that maps through the args, removes them if they are forbidden (defaulting to just forbidding password), and then compacts the array (the map returns nil in the removed spots, and an empty string looks weird/ugly with just a hanging comma when it prints), and joins it to a comma-separated string for the logger.

I have tested it locally and it seems to be working.

I have not been able to get the specs to run, individually or in bulk, so I did not write a test with it. If you would like to help me out w.r.t to getting the testing suite running I will gladly get one written.
