### PR TITLE
Skip integration tests when NO_BROWSER is set

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Ensure that you can build the project and run tests.
 
 ```
 bundle install
-bundle exec rake
+NO_BROWSER=true bundle exec rake
 ```
 
 By default rake doesn't run the integration tests.  The integration tests use capybara to run the tests in a real browser, (read more [here](https://github.com/voltrb/docs/blob/master/en/docs/testing.md)).  You can run with integration tests in a browser with:

--- a/lib/volt/spec/setup.rb
+++ b/lib/volt/spec/setup.rb
@@ -22,7 +22,7 @@ module Volt
         end
       end
 
-      unless ENV['BROWSER']
+      if ! ENV['BROWSER'] || ENV['NO_BROWSER']
         # Not running integration tests with ENV['BROWSER']
         RSpec.configuration.filter_run_excluding :type => :feature
       end


### PR DESCRIPTION
If `BROWSER` env var is set in the shell globally for other purposes, the test suite will fail.

I saw the Travis config has `NO_BROWSER=true` set, so I made it skip integration tests when it's set. I haven't found NO_BROWSER anywhere else in the code.