### PR TITLE
Add timeout to prevent each_binding from blocking UI for a long list

### DIFF
--- a/lib/volt/extra_core/extra_core.rb
+++ b/lib/volt/extra_core/extra_core.rb
@@ -8,6 +8,7 @@ require 'volt/extra_core/hash'
 require 'volt/extra_core/class'
 if RUBY_PLATFORM == 'opal'
   # TODO: != does not work with opal for some reason
+  require 'volt/extra_core/timeout'
 else
   require 'volt/extra_core/symbol'
 end

--- a/lib/volt/extra_core/timeout.rb
+++ b/lib/volt/extra_core/timeout.rb
@@ -1,0 +1,5 @@
+class Timeout
+  def initialize(time=0, &block)
+    `setTimeout(function(){#{block.call}}, time)`
+  end
+end

--- a/lib/volt/reactive/eventable.rb
+++ b/lib/volt/reactive/eventable.rb
@@ -78,8 +78,11 @@ module Volt
       if @listeners && @listeners[event]
         # TODO: We have to dup here because one trigger might remove another
         @listeners[event].dup.each do |listener|
-          # Call the event on each listener
-          listener.call(*args)
+          # Run in the next tick
+          Timeout.new 2 do
+            # Call the event on each listener
+            listener.call(*args)
+          end
         end
       end
     end


### PR DESCRIPTION
This speeds up the rendering a lot and will not freeze the tab and memory leak the page anymore.