### PR TITLE
A replacement for .sync on the client side

### DIFF
--- a/lib/volt/utils/promise_patch.rb
+++ b/lib/volt/utils/promise_patch.rb
@@ -14,6 +14,13 @@ class Promise
     @next = nil
   end
 
+  def method_missing(method_name, *args, &block)
+    self.then do |result|
+      result.send(method_name.to_sym, *args, &block)
+    end.fail do |error|
+      raise error
+    end
+  end
 
   def >>(promise)
     @next = promise


### PR DESCRIPTION
Now a promise can chain methods as well.
A promise can be chained with methods supported by the previous resolve object.

e.g. store._jobs.fetch.each ...
e.g. Promise.new.resolve([1, 2, 3]).length <= returns a promise that resolves into the
length of the array
e.g. Promise.new.resolve(4) + 3 <= returns a promise that resolves into 7

An error will be raised if the promise got rejected.