### PR TITLE
Deploy with Passenger

### DIFF
--- a/lib/volt/server.rb
+++ b/lib/volt/server.rb
@@ -35,7 +35,7 @@ module Rack
     def call(env)
       status, headers, body = @app.call(env)
 
-      if status == 304 && env['HTTP_CONNECTION'].downcase == 'keep-alive'
+      if status == 304 && env['HTTP_CONNECTION'] && env['HTTP_CONNECTION'].downcase == 'keep-alive'
         headers['Connection'] = 'keep-alive'
       end
 

--- a/lib/volt/server/rack/quiet_common_logger.rb
+++ b/lib/volt/server/rack/quiet_common_logger.rb
@@ -5,7 +5,7 @@ class QuietCommonLogger < Rack::CommonLogger
   @@ignore_extensions = %w(png jpg jpeg ico gif woff tff svg eot css js)
 
   def call(env)
-    path = env['REQUEST_PATH']
+    path = env['PATH_INFO']
     began_at = Time.now
     status, header, body = @app.call(env)
     header = Utils::HeaderHash.new(header)

--- a/spec/server/rack/quite_common_logger_spec.rb
+++ b/spec/server/rack/quite_common_logger_spec.rb
@@ -24,7 +24,7 @@ unless RUBY_PLATFORM == 'opal'
       end
 
       describe 'when request path has no file extension and request run over web socket' do
-        let(:env) { {'REQUEST_PATH' => '/file'} }
+        let(:env) { {'PATH_INFO' => '/file'} }
 
         it "calls 'log' method" do
           expect(subject).to receive(:log)
@@ -33,7 +33,7 @@ unless RUBY_PLATFORM == 'opal'
       end
 
       describe 'when request path has file extension' do
-        let(:env) { {'REQUEST_PATH' => '/file.ext'} }
+        let(:env) { {'PATH_INFO' => '/file.ext'} }
 
         it "doesn't call 'log' method" do
           expect(subject).not_to receive(:log)
@@ -42,7 +42,7 @@ unless RUBY_PLATFORM == 'opal'
       end
 
       describe 'when request run over web socket' do
-        let(:env) { {'REQUEST_PATH' => '/channel'} }
+        let(:env) { {'PATH_INFO' => '/channel'} }
 
         it "doesn't call 'log' method" do
           expect(subject).not_to receive(:log)


### PR DESCRIPTION
I'm, with @ylluminate, trying to deploy a application we're working with passenger. As soon as we tried we got the following error: https://gist.github.com/ylluminate/981957a7c4b0c38a522c

As I tried to investigate this I found an old thread saying that REQUEST_PATH is a legacy variable on rack. So after going through the rack-spec:http://rack.rubyforge.org/doc/SPEC.html, I made the change so we use PATH_INFO instead.

With that simple change I managed to get the application deployed, right now its giving a different error: 
```
Uncaught Error: ArgumentError: An error occurred while compiling: volt/extra_core/blank
invalid byte sequence in US-ASCII
  (in /home/user/apps/appname/dev/shared/bundle/ruby/2.1.0/bundler/gems/volt-15d9e7608a20/lib/volt/page/page.rb)(anonymous function) @ page.js:1
main.js:2 Uncaught ReferenceError: Opal is not defined
```

Haven't looked deep into this yet, but wanted to open this so we can talk about it.