### PR TITLE
Allow users to specify when the validation should happen.

### DIFF
--- a/lib/volt/extra_core/hash.rb
+++ b/lib/volt/extra_core/hash.rb
@@ -24,3 +24,24 @@
 #     end
 #   end
 # end
+class Hash
+  # Returns a hash that includes everything but the given keys.
+  #   hash = { a: true, b: false, c: nil}
+  #   hash.except(:c) # => { a: true, b: false}
+  #   hash # => { a: true, b: false, c: nil}
+  #
+  # This is useful for limiting a set of parameters to everything but a few known toggles:
+  #   @person.update(params[:person].except(:admin))
+  def except(*keys)
+    dup.except!(*keys)
+  end
+
+  # Replaces the hash without the given keys.
+  #   hash = { a: true, b: false, c: nil}
+  #   hash.except!(:c) # => { a: true, b: false}
+  #   hash # => { a: true, b: false }
+  def except!(*keys)
+    keys.each { |key| delete(key) }
+    self
+  end
+end

--- a/lib/volt/models/buffer.rb
+++ b/lib/volt/models/buffer.rb
@@ -77,6 +77,13 @@ module Volt
       options[:buffer]
     end
 
+    # Return true if the model hasn't been saved yet
+    def new?
+      @new
+    end
+
+    alias_method :new_record?, :new?
+
     def save_to
       options[:save_to]
     end

--- a/lib/volt/models/model.rb
+++ b/lib/volt/models/model.rb
@@ -116,6 +116,8 @@ module Volt
       @new
     end
 
+    alias_method :new_record?, :new?
+
     # Update the options
     def options=(options)
       @options     = options
@@ -219,7 +221,7 @@ module Volt
       new_value = wrap_value(value, [attribute_name])
 
       if old_value != new_value
-        # Track the old value, skip if we are in no_validate
+        # Track the old value, skip if we are in no_change_tracking
         attribute_will_change!(attribute_name, old_value) unless Volt.in_mode?(:no_change_tracking)
 
         # Assign the new value
@@ -420,12 +422,7 @@ module Volt
               # Some errors are present, revert changes
               revert_changes!
 
-              # After we revert, we need to validate again to get the error messages back
-              # TODO: Could probably cache the previous errors.
-              result = validate!.then do
-                # Reject the promise with the errors
-                Promise.new.reject(errs)
-              end
+              Promise.new.reject(errors)
             else
               # No errors, tell the persistor to handle the change (usually save)
 

--- a/lib/volt/models/validations.rb
+++ b/lib/volt/models/validations.rb
@@ -19,9 +19,9 @@ module Volt
           self.custom_validations ||= []
           custom_validations << block
         else
-          self.validations ||= {}
-          validations[field_name] ||= {}
-          validations[field_name].merge!(options)
+          self.validations                     ||= {}
+          validations[field_name]              ||= {create: {}, update: {}, both: {}}
+          validations[field_name][options[:on] || :both].merge!(options.except(:on))
         end
       end
     end
@@ -119,7 +119,8 @@ module Volt
 
         # Run through each validation
         validations.each_pair do |field_name, options|
-          options.each_pair do |validation, args|
+          merged_options = (new_record? ? options[:create] : options[:update]).merge options[:both]
+          merged_options.each_pair do |validation, args|
             # Call the specific validator, then merge the results back
             # into one large errors hash.
             klass = validation_class(validation, args)

--- a/lib/volt/models/validators/presence_validator.rb
+++ b/lib/volt/models/validators/presence_validator.rb
@@ -3,7 +3,7 @@ module Volt
     def self.validate(model, field_name, args)
       errors = {}
       value  = model.get(field_name)
-      if !value || value.blank?
+      unless value.present?
         if args.is_a?(Hash) && args[:message]
           message = args[:message]
         else

--- a/spec/models/validations_spec.rb
+++ b/spec/models/validations_spec.rb
@@ -12,6 +12,7 @@ describe Volt::Model do
       validate :name, length: 4
       validate :phone_number, phone_number: true
       validate :username, presence: true
+      validate :password, length: 8, on: :create
     end
   end
 
@@ -27,16 +28,36 @@ describe Volt::Model do
     end
   end
 
+  it 'should only validate password on new record' do
+    model.validate!.then do
+      expect(model.errors).to include(
+        password: ['must be at least 8 characters']
+      )
+    end
+
+    Volt::Model.no_validate do
+      model.assign_attributes({password: '123123123'}, false)
+    end
+
+    model.validate!.then do
+      expect(model.errors).to_not include(
+        password: ['must be at least 8 characters']
+      )
+    end
+  end
+
   it 'should return errors for all failed validations' do
-    model.validate!
-    expect(model.errors).to eq(
-      count: ['must be a number'],
-      description: ['needs to be longer'],
-      email: ['must be an email address'],
-      name: ['must be at least 4 characters'],
-      phone_number: ['must be a phone number with area or country code'],
-      username: ['must be specified']
-    )
+    model.validate!.then do |errs|
+      expect(errs).to eq(
+        count: ['must be a number'],
+        description: ['needs to be longer'],
+        email: ['must be an email address'],
+        name: ['must be at least 4 characters'],
+        phone_number: ['must be a phone number with area or country code'],
+        username: ['must be specified'],
+        password: ['must be at least 8 characters']
+      )
+    end
   end
 
   it 'should show all fields in marked errors once saved' do

--- a/spec/models/validations_spec.rb
+++ b/spec/models/validations_spec.rb
@@ -66,7 +66,7 @@ describe Volt::Model do
     buffer.save!
 
     expect(buffer.marked_errors.keys).to eq(
-      [:count, :description, :email, :name, :phone_number, :username]
+      [:count, :description, :email, :name, :phone_number, :username, :password]
     )
   end
 


### PR DESCRIPTION
Allow users to specify when the validation should happen. By default without the on: option the validation will happen when both the object is being created or the object is being updated. One could use on: :create to run the validation only when a new record is created or on: :update to run validation only when a record is updated.