### PR TITLE
Add test case for self closing tags in SandlebarsParser

### DIFF
--- a/spec/server/html_parser/sandlebars_parser_spec.rb
+++ b/spec/server/html_parser/sandlebars_parser_spec.rb
@@ -191,11 +191,9 @@ describe Volt::SandlebarsParser do
     test_html(html)
   end
 
-  # it "should warn you when you over close tags" do
-  #   html = "<div><p>test</p></div></div>"
-  #
-  #   handler = HTMLHandler.new
-  #   expect { Volt::SandlebarsParser.new(html, handler) }.to raise_error(Volt::HTMLParseError)
-  # end
+  it 'should close self closing elements' do
+    html = "<p><p>"
+    test_html(html, '<p></p><p></p>')
+  end
 end
 end

--- a/spec/server/html_parser/sandlebars_parser_spec.rb
+++ b/spec/server/html_parser/sandlebars_parser_spec.rb
@@ -192,8 +192,8 @@ describe Volt::SandlebarsParser do
   end
 
   it 'should close self closing elements' do
-    html = "<p><p>"
-    test_html(html, '<p></p><p></p>')
+    test_html '<p><p>', '<p></p><p></p>'
+    test_html '<p><span>1</span>2<p>3</p>', '<p><span>1</span>2</p><p>3</p>'
   end
 end
 end


### PR DESCRIPTION
# What's New?

  * added test cases for auto closing certain tags like `button`.
