### PR TITLE
Using promise to chain reload operations

### DIFF
--- a/spec/apps/kitchen_sink/app/main/controllers/main_controller.rb
+++ b/spec/apps/kitchen_sink/app/main/controllers/main_controller.rb
@@ -56,13 +56,21 @@ module Main
     end
 
     def jiggle
-      101.upto(500).each do |i|
-        page._items << i
-      end
+      changes = Promise.new
+      page._items = changes
+      `
+      setTimeout(function () {
+        #{changes.resolve(0.upto(100).to_a)}
+      }, 1000);
+      `
+      page._items = 901.upto(1000).to_a
+    end
 
-      0.upto(200).each do |i|
-        page._items.delete(i)
-      end
+    def wiggle
+      changes = Promise.new
+      changes.resolve(1.upto(200).to_a)
+      page._items = 901.upto(1000).to_a
+      page._items = changes
     end
 
     private

--- a/spec/apps/kitchen_sink/app/main/controllers/main_controller.rb
+++ b/spec/apps/kitchen_sink/app/main/controllers/main_controller.rb
@@ -8,6 +8,7 @@ module Main
     def index
       a = {}
       a[{}] = 5
+      page._items = 1.upto(100).to_a
     end
 
     def form_ready
@@ -52,6 +53,16 @@ module Main
 
     def set_show(value)
       page._show = value
+    end
+
+    def jiggle
+      101.upto(500).each do |i|
+        page._items << i
+      end
+
+      0.upto(200).each do |i|
+        page._items.delete(i)
+      end
     end
 
     private

--- a/spec/apps/kitchen_sink/app/main/views/main/bindings.html
+++ b/spec/apps/kitchen_sink/app/main/views/main/bindings.html
@@ -142,6 +142,7 @@
   </ul>
 
   <a id='each-jiggle' e-click='jiggle'>Jiggle</a>
+  <a id='each-wiggle' e-click='wiggle'>Wiggle</a>
 
   <h2>Content</h2>
 

--- a/spec/apps/kitchen_sink/app/main/views/main/bindings.html
+++ b/spec/apps/kitchen_sink/app/main/views/main/bindings.html
@@ -134,6 +134,15 @@
   <a id='showtrue' e-click='set_show(true)'>set _show true</a>
   <a id='showfalse' e-click='set_show(false)'>set _show false</a>
 
+  <h2>Each Bindings</h2>
+  <ul id='eachbinding'>
+    {{ _items.each do |item| }}
+    <li>{{ item }}</li>
+    {{ end }}
+  </ul>
+
+  <a id='each-jiggle' e-click='jiggle'>Jiggle</a>
+
   <h2>Content</h2>
 
   <p id="escapeContent">{{{this is {{escaped}}}}}</p>

--- a/spec/integration/bindings_spec.rb
+++ b/spec/integration/bindings_spec.rb
@@ -186,6 +186,28 @@ describe 'bindings test', type: :feature, sauce: true do
     end
   end
 
+  describe 'each binding' do
+    it 'should display the right amount of content' do
+      visit '/'
+
+      click_link 'Bindings'
+
+      expect(page).to have_selector('#eachbinding li', count: 100)
+    end
+
+    it 'should display the right amount of content after a lot of changes in the bindings' do
+      visit '/'
+
+      click_link 'Bindings'
+
+      click_link 'Jiggle'
+
+      sleep 3
+
+      expect(page).to have_selector('#eachbinding li', count: 300)
+    end
+  end
+
   describe 'if/unless binding' do
     it 'should show corret text' do
       visit '/'

--- a/spec/integration/bindings_spec.rb
+++ b/spec/integration/bindings_spec.rb
@@ -196,7 +196,7 @@ describe 'bindings test', type: :feature, sauce: true do
       expect(page).to have_selector('#eachbinding li', count: 100)
     end
 
-    it 'should display the last assignment regardless of the previous resolved a bit later' do
+    it 'should display the last assignment even if the previous assignment resolved afterwards' do
       visit '/'
 
       click_link 'Bindings'
@@ -209,7 +209,7 @@ describe 'bindings test', type: :feature, sauce: true do
       expect(page).to have_selector('#eachbinding li', count: 100)
     end
 
-    it 'should display the last assignment regardless whether the promise has already been resolved before' do
+    it 'should display the last assignment regardless whether the previous promise has already been resolved' do
       visit '/'
 
       click_link 'Bindings'

--- a/spec/integration/bindings_spec.rb
+++ b/spec/integration/bindings_spec.rb
@@ -192,10 +192,11 @@ describe 'bindings test', type: :feature, sauce: true do
 
       click_link 'Bindings'
 
+      expect(find('#eachbinding li:first-child')).to have_content('1')
       expect(page).to have_selector('#eachbinding li', count: 100)
     end
 
-    it 'should display the right amount of content after a lot of changes in the bindings' do
+    it 'should display the last assignment regardless of the previous resolved a bit later' do
       visit '/'
 
       click_link 'Bindings'
@@ -204,7 +205,21 @@ describe 'bindings test', type: :feature, sauce: true do
 
       sleep 3
 
-      expect(page).to have_selector('#eachbinding li', count: 300)
+      expect(find('#eachbinding li:first-child')).to have_content('901')
+      expect(page).to have_selector('#eachbinding li', count: 100)
+    end
+
+    it 'should display the last assignment regardless whether the promise has already been resolved before' do
+      visit '/'
+
+      click_link 'Bindings'
+
+      click_link 'Wiggle'
+
+      sleep 3
+
+      expect(find('#eachbinding li:first-child')).to have_content('1')
+      expect(page).to have_selector('#eachbinding li', count: 200)
     end
   end
 


### PR DESCRIPTION
I think this way the concern that getter might resolve in the middle of the reload call is solved using promise as it will chain the operations until the previous ops have been resolved.