### PR TITLE
Coverage increases (82.95%) and typo fix in ChannelStub#initialize()

### DIFF
--- a/lib/volt/page/channel_stub.rb
+++ b/lib/volt/page/channel_stub.rb
@@ -13,7 +13,7 @@ module Volt
 
     attr_reader :state, :error, :reconnect_interval
 
-    def initiailze
+    def initialize
       @state = :connected
     end
 

--- a/spec/models/persistors/store_spec.rb
+++ b/spec/models/persistors/store_spec.rb
@@ -27,4 +27,12 @@ describe Volt::Persistors::Store do
 
     @model << 4
   end
+
+  it 'passes removed() to changed() by default' do
+    model     = Volt::Model.new(abc: 123)
+    persistor = Volt::Persistors::Store.new(model)
+    expect(persistor.removed(:abc)).to eq(persistor.changed(:abc))
+    model._abc = 456
+    expect(persistor.removed(:abc)).to eq(persistor.changed(:abc))
+  end
 end

--- a/spec/tasks/dispatcher_spec.rb
+++ b/spec/tasks/dispatcher_spec.rb
@@ -54,9 +54,9 @@ if RUBY_PLATFORM != 'opal'
     it 'closes the channel' do
       dispatcher = Volt::Dispatcher.new
       channel    = Volt::ChannelStub.new
-      hmmm       = dispatcher.close_channel(channel)
-      binding.pry
-      puts '.'
+      # This doesn't do much except find typos, which is the only reason
+      # I haven't deleted it. Work in progress -@RickCarlino
+      this_spec_needs_improvement = dispatcher.close_channel(channel)
     end
   end
 end

--- a/spec/tasks/dispatcher_spec.rb
+++ b/spec/tasks/dispatcher_spec.rb
@@ -50,5 +50,13 @@ if RUBY_PLATFORM != 'opal'
 
       Volt::Dispatcher.new.dispatch(channel, [0, 'TestTask', :allowed_method, {}, ' it', ' works'])
     end
+
+    it 'closes the channel' do
+      dispatcher = Volt::Dispatcher.new
+      channel    = Volt::ChannelStub.new
+      hmmm       = dispatcher.close_channel(channel)
+      binding.pry
+      puts '.'
+    end
   end
 end


### PR DESCRIPTION
# In This PR

 * Typo fix for `StubChannel`
 * Test case that covers `Persistors::Base`'s last untested line
 * Incomplete (but working) test case for `Dispatcher#close_channel`. It works, but need to dig in a little bit deeper on a seperate branch. Probably will require a refactor in some places.