### PR TITLE
Auto associate user to model when using own_by_user

### DIFF
--- a/lib/volt/models/permissions.rb
+++ b/lib/volt/models/permissions.rb
@@ -9,9 +9,13 @@ module Volt
         #
         # @param key [Symbol] the name of the attribute to store
         def own_by_user(key = :user_id)
-          *resource_name, _discard = key.to_s.split('_')
-          belongs_to resource_name.join("_")
-          # When the model is created, assign it the user_id (if the user is logged in)
+          relation, pattern = key.to_s, /_id$/
+          if relation.match(pattern)
+            belongs_to key.to_s.gsub(pattern, '')
+          else
+            raise "You tried to auto associate a model using #{key}, but #{key} "\
+                  "does not end in `_id`"
+          end          # When the model is created, assign it the user_id (if the user is logged in)
           on(:new) do
             # Only assign the user_id if there isn't already one and the user is logged in.
             if _user_id.nil? && !(user_id = Volt.current_user_id).nil?

--- a/lib/volt/models/permissions.rb
+++ b/lib/volt/models/permissions.rb
@@ -9,6 +9,7 @@ module Volt
         #
         # @param key [Symbol] the name of the attribute to store
         def own_by_user(key = :user_id)
+          belongs_to :user
           # When the model is created, assign it the user_id (if the user is logged in)
           on(:new) do
             # Only assign the user_id if there isn't already one and the user is logged in.

--- a/lib/volt/models/permissions.rb
+++ b/lib/volt/models/permissions.rb
@@ -9,7 +9,8 @@ module Volt
         #
         # @param key [Symbol] the name of the attribute to store
         def own_by_user(key = :user_id)
-          belongs_to :user
+          *resource_name, _discard = key.to_s.split('_')
+          belongs_to resource_name.join("_")
           # When the model is created, assign it the user_id (if the user is logged in)
           on(:new) do
             # Only assign the user_id if there isn't already one and the user is logged in.

--- a/spec/models/permissions_spec.rb
+++ b/spec/models/permissions_spec.rb
@@ -47,6 +47,13 @@ class ::TestUpdateReadCheck < Volt::Model
 end
 
 describe 'model permissions' do
+  let(:user_todo) { TestUserTodo.new }
+
+  it 'auto-associates users via own_by_user' do
+    #TODO: better assertions
+    expect(user_todo.respond_to?(:user)).to be(true)
+  end
+
   it 'should follow CRUD states when checking permissions' do
     todo = TestUserTodoWithCrudStates.new.buffer
 


### PR DESCRIPTION
# What's New?

 * When you `own_by_user`, it will auto add the `belongs_to :user` for you.
