### PR TITLE
update selenium-webdriver to 2.45

### DIFF
--- a/templates/project/Gemfile.tt
+++ b/templates/project/Gemfile.tt
@@ -23,7 +23,7 @@ group :test do
   gem 'rspec', '~> 3.2.0'
   gem 'opal-rspec', '~> 0.4.2'
   gem 'capybara', '~> 2.4.2'
-  gem 'selenium-webdriver', '~> 2.43.0'
+  gem 'selenium-webdriver', '~> 2.45.0'
   gem 'chromedriver2-helper', '~> 0.0.8'
   gem 'poltergeist', '~> 1.5.0'
 end


### PR DESCRIPTION
webdriver 2.43 only supports up to Firefox 32. With 2.45, the tests work out of the box on the latest build of FF 38.