### PR TITLE
to_json that's actually JSON

### DIFF
--- a/lib/volt/models/array_model.rb
+++ b/lib/volt/models/array_model.rb
@@ -237,6 +237,11 @@ module Volt
       array
     end
 
+    def to_json
+      to_a.to_json
+    end
+
+
     def inspect
       Computation.run_without_tracking do
         # Track on size

--- a/lib/volt/models/model.rb
+++ b/lib/volt/models/model.rb
@@ -352,6 +352,10 @@ module Volt
       end
     end
 
+    def to_json
+      to_h.to_json
+    end
+
     private
     def run_initial_setup(initial_setup)
       # Save the changes

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -591,4 +591,14 @@ describe Volt::Model do
         'Model does not have a parent and cannot be deleted.')
     end
   end
+
+  describe 'serialization' do
+    it 'supports JSON via to_json' do
+      model = Volt::Model.new({})
+      expect(model.to_json).to eq(model.to_h.to_json)
+      expect(model.to_json).to eq(model.to_h.to_json)
+      array_model = Volt::ArrayModel.new([model])
+      expect(array_model.to_json).to eq(array_model.to_a.to_json)
+    end
+  end
 end


### PR DESCRIPTION
# Problem

 1. You're building an HTTP API
 2. You call `render json: some_model`
 3. You get back a stringified `inspect()`ed version of the model (not JSON)
 4. You go back and write `render json: some_model.to_h`
 5. It works, but added extra code to the controller

# In This PR

 Ability to call `render json: my_model_or_array_model` without needing to call `to_a` or `to_h` first.

