### PR TITLE
Actions for http controllers

### DIFF
--- a/lib/volt/controllers/actions.rb
+++ b/lib/volt/controllers/actions.rb
@@ -62,7 +62,12 @@ module Volt
 
       begin
         filtered_callbacks.each do |callback|
-          instance_eval(&callback)
+          case callback
+          when Symbol
+            send(callback)
+          when Proc
+            instance_eval(&callback)
+          end
         end
 
         return false

--- a/lib/volt/router/routes.rb
+++ b/lib/volt/router/routes.rb
@@ -68,6 +68,7 @@ module Volt
     end
 
     # Add server side routes
+    
     def get(path, params)
       create_route(:get, path, params)
     end
@@ -86,6 +87,35 @@ module Volt
 
     def delete(path, params)
       create_route(:delete, path, params)
+    end
+
+    #Create rest endpoints
+    def rest(path, params)
+      endpoints = (params.delete(:only) || [:index, :show, :create, :update, :destroy]).to_a
+      endpoints = endpoints - params.delete(:except).to_a
+      endpoints.each do |endpoint|
+        self.send(('restful_' + endpoint.to_s).to_sym, path, params)
+      end
+    end
+
+    def restful_index(base_path, params)
+      get(base_path, params.merge(action: 'index'))
+    end
+
+    def restful_create(base_path, params)
+      post(base_path, params.merge(action: 'create'))
+    end
+
+    def restful_show(base_path, params)
+      get(path_with_id(base_path), params.merge(action: 'show'))
+    end
+
+    def restful_update(base_path, params)
+      put(path_with_id(base_path), params.merge(action: 'update'))
+    end
+
+    def restful_destroy(base_path, params)
+      delete(path_with_id(base_path), params.merge(action: 'destroy'))
     end
 
     # Takes in params and generates a path and the remaining params
@@ -295,6 +325,11 @@ module Volt
     # Check if a string has a binding in it
     def has_binding?(string)
       string.index('{{') && string.index('}}')
+    end
+
+    #Append an id to a given path
+    def path_with_id(base_path)
+      base_path + '/{{ id  }}'
     end
   end
 end

--- a/lib/volt/server/rack/http_request.rb
+++ b/lib/volt/server/rack/http_request.rb
@@ -5,7 +5,7 @@ module Volt
   # A request object for a HttpController. See Rack::Request for more details
   class HttpRequest < Rack::Request
     # Returns the request format
-    # /blub/index.html => html
+    # /acticles/index.html => html
     # Defaults to the media_type of the request
     def format
       path_format || media_type

--- a/spec/controllers/http_controller_spec.rb
+++ b/spec/controllers/http_controller_spec.rb
@@ -7,7 +7,12 @@ if RUBY_PLATFORM != 'opal'
 
   describe Volt::HttpController do
     class TestHttpController < Volt::HttpController
+      attr_reader :ran_action1
       attr_reader :action_called
+      attr_reader :stoped_action_called
+
+      before_action :run_action1
+      before_action :run_action2, only: [:stoped_action]
 
       def just_call_an_action
         @action_called = true
@@ -44,6 +49,18 @@ if RUBY_PLATFORM != 'opal'
 
       def access_body
         render json: JSON.parse(request.body.read)
+      end
+
+      def stoped_action
+        @stoped_action_called = true
+      end
+
+      def run_action1
+        @ran_action1 = true
+      end
+
+      def run_action2
+        stop_chain
       end
     end
 
@@ -127,6 +144,16 @@ if RUBY_PLATFORM != 'opal'
       response = request.post('http://example.com/test.html', input:
         { test: 'params' }.to_json)
       expect(response.body).to eq({ test: 'params' }.to_json)
+    end
+
+    it 'should run the before action' do
+      controller.perform(:render_plain_text)
+      expect(controller.ran_action1).to be(true)
+    end
+
+    it 'should not call the stoped_action' do
+      controller.perform(:stoped_action)
+      expect(controller.stoped_action_called).to be_nil
     end
   end
 end

--- a/spec/router/routes_spec.rb
+++ b/spec/router/routes_spec.rb
@@ -246,4 +246,73 @@ describe Volt::Routes do
 
     params = @routes.url_to_params('/blog/20')
   end
+
+  it 'should setup RESTful routes' do
+    routes do
+      rest '/api/v1/articles', controller: 'articles'
+    end
+
+    params = @routes.url_to_params(:get, '/api/v1/articles')
+    expect(params).to eq(controller: 'articles', action: 'index')
+
+    params = @routes.url_to_params(:get, '/api/v1/articles/1')
+    expect(params).to eq(controller: 'articles', action: 'show', id: '1')
+
+    params = @routes.url_to_params(:post, '/api/v1/articles')
+    expect(params).to eq(controller: 'articles', action: 'create')
+
+    params = @routes.url_to_params(:put, '/api/v1/articles/1')
+    expect(params).to eq(controller: 'articles', action: 'update', id: '1')
+
+    params = @routes.url_to_params(:delete, '/api/v1/articles/1')
+    expect(params).to eq(controller: 'articles', action: 'destroy', id: '1')
+  end
+
+  it 'should only setup desired RESTful routes' do
+    routes do
+      rest '/api/v1/articles', controller: 'articles', only: [:index, :show]
+    end
+
+    params = @routes.url_to_params(:get, '/api/v1/articles')
+    expect(params).to eq(controller: 'articles', action: 'index')
+
+    params = @routes.url_to_params(:get, '/api/v1/articles/1')
+    expect(params).to eq(controller: 'articles', action: 'show', id: '1')
+
+    expect(@routes.url_to_params(:post, '/api/v1/articles')).to be_nil
+    expect(@routes.url_to_params(:put, '/api/v1/articles/1')).to be_nil
+    expect(@routes.url_to_params(:delete, '/api/v1/articles/1')).to be_nil
+
+    routes do
+      rest '/api/v1/articles', controller: 'articles', only: [:update, :destroy, :create]
+    end
+
+    expect(@routes.url_to_params(:get, '/api/v1/articles')).to be_nil
+    expect(@routes.url_to_params(:get, '/api/v1/articles/1')).to be_nil
+
+    params = @routes.url_to_params(:post, '/api/v1/articles')
+    expect(params).to eq(controller: 'articles', action: 'create')
+
+    params = @routes.url_to_params(:put, '/api/v1/articles/1')
+    expect(params).to eq(controller: 'articles', action: 'update', id: '1')
+
+    params = @routes.url_to_params(:delete, '/api/v1/articles/1')
+    expect(params).to eq(controller: 'articles', action: 'destroy', id: '1')
+  end
+
+  it 'should exclude undesired RESTful routes' do
+    routes do
+      rest '/api/v1/articles', controller: 'articles', except: [:update, :destroy, :create]
+    end
+
+    params = @routes.url_to_params(:get, '/api/v1/articles')
+    expect(params).to eq(controller: 'articles', action: 'index')
+
+    params = @routes.url_to_params(:get, '/api/v1/articles/1')
+    expect(params).to eq(controller: 'articles', action: 'show', id: '1')
+
+    expect(@routes.url_to_params(:post, '/api/v1/articles')).to be_nil
+    expect(@routes.url_to_params(:put, '/api/v1/articles/1')).to be_nil
+    expect(@routes.url_to_params(:delete, '/api/v1/articles/1')).to be_nil
+  end
 end


### PR DESCRIPTION
# Changes
* Added a ```rest``` keyword for routes to generate index, show, create, update and delete routes for a resource
* Integrated actions into http_controllers
* Actions now use ```send``` instead of instance_eval when a ```Symbol``` or ```String``` is passed as an argument. This allows the usage of private methods.