### PR TITLE
Forward Promise#to_json to value, error or nil (respectivly)

### DIFF
--- a/lib/volt/utils/promise.rb
+++ b/lib/volt/utils/promise.rb
@@ -127,6 +127,10 @@ class Promise
     @next = nil
   end
 
+  def to_json(*args)
+    (@value || @error || nil).to_json(*args)
+  end
+
   def value
     if Promise === @value
       @value.value

--- a/spec/utils/promise_extensions_spec.rb
+++ b/spec/utils/promise_extensions_spec.rb
@@ -39,4 +39,12 @@ describe Promise do
 
     expect(count_occurences(b.inspect, 'Promise')).to eq(1)
   end
+
+  it 'delegates to_json to the value or error (respectively)' do
+    a = Promise.new.tap { |p| p.resolve(hello: 'world') }
+    expect(a.to_json).to eq("{\"hello\":\"world\"}")
+    b = Promise.new.tap { |p| p.reject(goodbye: 'jupiter') }
+    expect(b.to_json).to eq("{\"goodbye\":\"jupiter\"}")
+    expect(Promise.new.to_json).to eq('null')
+  end
 end


### PR DESCRIPTION
# Original Problem

 * `to_json` on Model and ArrayModel was being forward to `inspect`.
 * Patched that in a pull request.

# Minor Issue

 * The query API changed in 0.9.3pre to always return a promise, so `Promise#to_json` was forwarding to `inspect` now.

# The Fix

 * Forward `to_json` to `@value`
 * If not, forward to `@error`
 * If not, forward to `nil` (which will render 'null' as string)
