### PR TITLE
fixed url_with and added spec

### DIFF
--- a/lib/volt/models/url.rb
+++ b/lib/volt/models/url.rb
@@ -97,8 +97,8 @@ module Volt
       new_url
     end
 
-    def url_with(params)
-      url_for(params.to_h.merge(params))
+    def url_with(passed_params)
+      url_for(params.to_h.merge(passed_params))
     end
 
     # Called when the state has changed and the url in the

--- a/spec/models/url_spec.rb
+++ b/spec/models/url_spec.rb
@@ -63,4 +63,20 @@ describe Volt::URL do
       expect(subject.url_for params).to eq uri
     end
   end
+
+  describe '#url_with' do
+    let(:uri) { 'http://voltframework.com:8888/path/1?query=val&page=1#fragment' }
+    let(:fake_router) do
+      router = Volt::Routes.new
+
+      router.define do
+        client '/path/{{ id }}', view: 'blog/show'
+      end
+    end
+
+    it 'regenerates the URL and merges the given params' do
+      params = { page: 1 }
+      expect(subject.url_with params).to eq uri
+    end
+  end
 end


### PR DESCRIPTION
url_with was not returning a valid path because the param function was being overwritten by the "passed" parameter with the same name 'param'.  changed the name of the parameter in url_with