### PR TITLE
Automatically use ArrayModel subclasses.

### DIFF
--- a/lib/volt/models/array_model.rb
+++ b/lib/volt/models/array_model.rb
@@ -256,7 +256,7 @@ module Volt
     end
 
     def new_array_model(*args)
-      ArrayModel.new(*args)
+      Volt::ArrayModel.class_at_path(options[:path]).new(*args)
     end
 
     # Convert the model to an array all of the way down
@@ -319,6 +319,10 @@ module Volt
 
     # We need to setup the proxy methods below where they are defined.
     proxy_with_load :[], :size, :last, :reverse, :all, :to_a
+
+    def self.process_class_name(name)
+      name.pluralize
+    end
 
   end
 end

--- a/lib/volt/models/model.rb
+++ b/lib/volt/models/model.rb
@@ -305,7 +305,7 @@ module Volt
       options         = options.dup
       options[:query] = []
 
-      ArrayModel.new(attributes, options)
+      Volt::ArrayModel.class_at_path(options[:path]).new(attributes, options)
     end
 
     def inspect
@@ -414,6 +414,10 @@ module Volt
       if defined?(RootModels)
         RootModels.add_model_class(subclass)
       end
+    end
+
+    def self.process_class_name(name)
+      name.singularize
     end
 
   end

--- a/lib/volt/models/model_helpers/model_helpers.rb
+++ b/lib/volt/models/model_helpers/model_helpers.rb
@@ -77,26 +77,28 @@ module Volt
       def class_at_path(path)
         if path
           begin
-            # remove the _ and then singularize
+            # remove the _ and then singularize/pluralize
             if path.last == :[]
               index = -2
             else
               index = -1
             end
 
-            klass_name = path[index].singularize.camelize
+            # process_class_name is defined by Model/ArrayModel as
+            # singularize/pluralize
+            klass_name = process_class_name(klass_name = path[index]).camelize
 
             # Lookup the class
             klass = Object.const_get(klass_name)
 
             # Use it if it is a model
-            klass = Model unless klass < Model
+            klass = self unless klass < self
           rescue NameError => e
             # Ignore exception, just means the model isn't defined
-            klass = Model
+            klass = self
           end
         else
-          klass = Model
+          klass = self
         end
 
         klass

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -6,6 +6,9 @@ end
 class Item < Volt::Model
 end
 
+class Items < Volt::ArrayModel
+end
+
 class TestAssignsMethod < Volt::Model
   def name=(val)
     self._name = val
@@ -602,5 +605,12 @@ describe Volt::Model do
       array_model = Volt::ArrayModel.new([model])
       expect(array_model.to_json).to eq(array_model.to_a.to_json)
     end
+  end
+
+  it 'creates sub-arrays with correct classes' do
+    class Items < Volt::ArrayModel; end
+    model = Volt::Model.new
+    model._items! << {}
+    expect(model._items).to be_instance_of Items
   end
 end


### PR DESCRIPTION
This works just like Model subclasses: any ArrayModel subclass with the same name as the used property will automatically be used.