### PR TITLE
Appending Volt::Model to an Array::Model sets the array as parent

### DIFF
--- a/lib/volt/models/array_model.rb
+++ b/lib/volt/models/array_model.rb
@@ -323,7 +323,7 @@ module Volt
         end
 
         # Set the new path and the persistor.
-        model.options = @options.merge(path: @options[:path] + [:[]])
+        model.options = @options.merge(parent: self, path: @options[:path] + [:[]])
       else
         model = wrap_values([model]).first
       end

--- a/spec/models/array_model_spec.rb
+++ b/spec/models/array_model_spec.rb
@@ -50,4 +50,17 @@ describe Volt::ArrayModel do
       end
     end
   end
+  context "appending a model" do
+    it "sets the parent to self" do
+      item = Volt::Model.new
+      array = Volt::ArrayModel.new([], { path: [:items],  parent: double("StoreRoot") })
+      array << item
+      expect(item.parent).to eq(array)
+
+      sub = Volt::Model.new
+      item._sub_items << sub
+      expect(sub.parent).to eq(item._sub_items)
+    end
+  end
+
 end


### PR DESCRIPTION
When you appends a model to an array model it sets the parent to the store root, raising a error when you try to destroy that model later

```ruby
item = store._items << Volt::Model.new
item.then(&:destroy) => #<Promise(70216442881060): #<NoMethodError: undefined method `to_sym' for #<Volt::Model id: "f415..fadb">>>
```

This PR fix this by setting the parent correctly to the ArrayModel we are appending to