### PR TITLE
sass template support

### DIFF
--- a/lib/volt/server/rack/asset_files.rb
+++ b/lib/volt/server/rack/asset_files.rb
@@ -88,7 +88,7 @@ module Volt
     end
 
     def css_file(locator)
-      @assets << [:css_file, prepare_locator(locator, ['css','scss'])]
+      @assets << [:css_file, prepare_locator(locator, ['css','scss','sass'])]
     end
 
     def prepare_locator(locator, valid_extensions)
@@ -171,8 +171,8 @@ module Volt
             # Don't import any css/scss files that start with an underscore, so scss partials
             # aren't imported by default:
             #  http://sass-lang.com/guide
-            css_files += Dir["#{path}/**/[^_]*.{css,scss}"].sort.map do |folder|
-              css_path = '/assets' + folder[path.size..-1].gsub(/[.]scss$/, '')
+            css_files += Dir["#{path}/**/[^_]*.{css,scss,sass}"].sort.map do |folder|
+              css_path = '/assets' + folder[path.size..-1].gsub(/[.](scss|sass)$/, '')
               css_path += '.css' unless css_path =~ /[.]css$/
               css_path
             end

--- a/lib/volt/server/rack/component_paths.rb
+++ b/lib/volt/server/rack/component_paths.rb
@@ -58,8 +58,21 @@ module Volt
     def require_in_components(volt_app)
       if RUBY_PLATFORM == 'opal'
       else
+
+        # Load component initializers incase they extend Volt functionality
         app_folders do |app_folder|
           $LOAD_PATH.unshift(app_folder)
+          
+           initializers = []
+           initializers += Dir["#{app_folder}/*/config/initializers/*.rb"]
+           initializers += Dir["#{app_folder}/*/config/initializers/server/*.rb"]
+
+           initializers.each do |initializer|
+             require(initializer)
+           end
+        end
+
+        app_folders do |app_folder|
 
           # Sort so we get consistent load order across platforms
           Dir["#{app_folder}/*/{controllers,models,tasks}/*.rb"].each do |ruby_file|

--- a/lib/volt/volt/server_setup/app.rb
+++ b/lib/volt/volt/server_setup/app.rb
@@ -61,10 +61,10 @@ module Volt
         files += Dir[Volt.root + '/config/initializers/server/*.rb']
 
         # Get initializers for each component
-        component_paths.app_folders do |app_folder|
-          files += Dir["#{app_folder}/*/config/initializers/*.rb"]
-          files += Dir["#{app_folder}/*/config/initializers/server/*.rb"]
-        end
+        #component_paths.app_folders do |app_folder|
+        #  files += Dir["#{app_folder}/*/config/initializers/*.rb"]
+        #  files += Dir["#{app_folder}/*/config/initializers/server/*.rb"]
+        #end
 
         files.each do |initializer|
           require(initializer)


### PR DESCRIPTION
There are two templating versions supported by the SASS preprocessor. The .scss file format is already supported by volt but the .sass format is not. This commit adds support for the latter.