### PR TITLE
subclass of custom Volt::Model should inherit custom Volt::ArrayModel if it exists

### DIFF
--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -9,6 +9,9 @@ end
 class Items < Volt::ArrayModel
 end
 
+class SubItem < Item
+end
+
 class TestAssignsMethod < Volt::Model
   def name=(val)
     self._name = val
@@ -611,5 +614,11 @@ describe Volt::Model do
     model = Volt::Model.new
     model._items << {}
     expect(model._items).to be_instance_of Items
+  end
+
+  it 'assigns the superclass\'s custom ArrayModel if it exists' do
+    model = Volt::Model.new
+    model._sub_items << {}
+    expect(model._sub_items).to be_instance_of Items
   end
 end


### PR DESCRIPTION
This is a fix for issue https://github.com/voltrb/volt/issues/286.