### PR TITLE
Add support for lifecycle callbacks.

### DIFF
--- a/app/volt/tasks/query_tasks.rb
+++ b/app/volt/tasks/query_tasks.rb
@@ -7,7 +7,7 @@ class QueryTasks < Volt::Task
       # For requests from the client (with @channel), we track the channel
       # so we can send the results back.  Server side requests don't stay live,
       # they simply return to :dirty once the query is issued.
-      @channel.user_id = Volt.current_user_id
+      @channel.update_user_id(Volt.current_user_id)
 
       # live_query.add_channel(@channel)
     end

--- a/app/volt/tasks/user_tasks.rb
+++ b/app/volt/tasks/user_tasks.rb
@@ -21,4 +21,10 @@ class UserTasks < Volt::Task
       end
     end
   end
+
+  def logout(logout_info)
+    # Remove user_id from user's channel
+    @channel.update_user_id(nil) if @channel
+  end
+
 end

--- a/app/volt/tasks/user_tasks.rb
+++ b/app/volt/tasks/user_tasks.rb
@@ -22,7 +22,7 @@ class UserTasks < Volt::Task
     end
   end
 
-  def logout(logout_info)
+  def logout
     # Remove user_id from user's channel
     @channel.update_user_id(nil) if @channel
   end

--- a/lib/volt/server/socket_connection_handler.rb
+++ b/lib/volt/server/socket_connection_handler.rb
@@ -113,12 +113,15 @@ module Volt
         begin
           @@dispatcher.close_channel(self)
 
-          # Trigger a client disconnect event
-          @@dispatcher.volt_app.trigger!("client_disconnect")
+          # Check for volt_app (@@dispatcher could be an ErrorDispatcher)
+          if @@dispatcher.respond_to(:volt_app)
+            # Trigger a client disconnect event
+            @@dispatcher.volt_app.trigger!("client_disconnect")
 
-          # Trigger a user disconnect event even if the user hasn't logged out
-          if @user_id
-            @@dispatcher.volt_app.trigger!("user_disconnect", @user_id)
+            # Trigger a user disconnect event even if the user hasn't logged out
+            if @user_id
+              @@dispatcher.volt_app.trigger!("user_disconnect", @user_id)
+            end
           end
           
         rescue DRb::DRbConnError => e

--- a/lib/volt/server/socket_connection_handler.rb
+++ b/lib/volt/server/socket_connection_handler.rb
@@ -114,7 +114,7 @@ module Volt
           @@dispatcher.close_channel(self)
 
           # Check for volt_app (@@dispatcher could be an ErrorDispatcher)
-          if @@dispatcher.respond_to(:volt_app)
+          if @@dispatcher.respond_to?(:volt_app)
             # Trigger a client disconnect event
             @@dispatcher.volt_app.trigger!("client_disconnect")
 

--- a/lib/volt/server/socket_connection_handler.rb
+++ b/lib/volt/server/socket_connection_handler.rb
@@ -16,6 +16,9 @@ module Volt
       @@channels ||= []
       @@channels << self
 
+      # Trigger a client connect event
+      @@dispatcher.volt_app.trigger!("client_connect")
+
     end
 
     def update_user_id(user_id)
@@ -43,6 +46,10 @@ module Volt
 
     def self.dispatcher
       @@dispatcher
+    end
+
+    def self.channels
+      @@channels
     end
 
     # Sends a message to all, optionally skipping a users channel
@@ -105,6 +112,9 @@ module Volt
 
         begin
           @@dispatcher.close_channel(self)
+
+          # Trigger a client disconnect event
+          @@dispatcher.volt_app.trigger!("client_disconnect")
 
           # Trigger a user disconnect event even if the user hasn't logged out
           if @user_id

--- a/lib/volt/server/socket_connection_handler.rb
+++ b/lib/volt/server/socket_connection_handler.rb
@@ -103,13 +103,14 @@ module Volt
         # Remove ourself from the available channels
         @@channels.delete(self)
 
-        # Trigger a user disconnect event even if the user hasn't logged out
-        if @user_id
-          @@dispatcher.volt_app.trigger!("user_disconnect", @user_id)
-        end
-
         begin
           @@dispatcher.close_channel(self)
+
+          # Trigger a user disconnect event even if the user hasn't logged out
+          if @user_id
+            @@dispatcher.volt_app.trigger!("user_disconnect", @user_id)
+          end
+          
         rescue DRb::DRbConnError => e
         # ignore drb read of @@dispatcher error if child has closed
         end

--- a/lib/volt/volt/server_setup/app.rb
+++ b/lib/volt/volt/server_setup/app.rb
@@ -10,6 +10,9 @@ end
 module Volt
   module ServerSetup
     module App
+      # Include Eventable to allow for lifecycle callbacks
+      include Eventable
+      
       # The root url is where the volt app is mounted
       attr_reader :root_url
       # The app url is where the app folder (and sprockets) is mounted

--- a/lib/volt/volt/users.rb
+++ b/lib/volt/volt/users.rb
@@ -115,7 +115,7 @@ module Volt
 
     def logout
       # Notify the backend so we can remove the user_id from the user's channel
-      UserTasks.logout(user_id: Volt.current_app.cookies._user_id)
+      UserTasks.logout
       
       # Remove the cookie so user is no longer logged in
       Volt.current_app.cookies.delete(:user_id)

--- a/lib/volt/volt/users.rb
+++ b/lib/volt/volt/users.rb
@@ -114,6 +114,10 @@ module Volt
     end
 
     def logout
+      # Notify the backend so we can remove the user_id from the user's channel
+      UserTasks.logout(user_id: Volt.current_app.cookies._user_id)
+      
+      # Remove the cookie so user is no longer logged in
       Volt.current_app.cookies.delete(:user_id)
     end
 

--- a/spec/apps/kitchen_sink/app/main/config/routes.rb
+++ b/spec/apps/kitchen_sink/app/main/config/routes.rb
@@ -14,6 +14,7 @@ client '/missing', action: 'missing'
 client '/require_test', action: 'require_test'
 client '/images', action: 'images'
 client '/login_from_task', action: 'login_from_task'
+client '/callbacks', action: 'callbacks'
 
 # Events
 client '/events', component: 'main', controller: 'events', action: 'index'

--- a/spec/apps/kitchen_sink/app/main/controllers/main_controller.rb
+++ b/spec/apps/kitchen_sink/app/main/controllers/main_controller.rb
@@ -92,6 +92,9 @@ module Main
       LoginTasks.login_first_user
     end
 
+    def callbacks
+    end
+
     private
 
     # the main template contains a #template binding that shows another

--- a/spec/apps/kitchen_sink/app/main/models/user.rb
+++ b/spec/apps/kitchen_sink/app/main/models/user.rb
@@ -6,4 +6,22 @@ class User < Volt::User
 
   validate login_field, unique: true, length: 8
   validate :email, email: true
+
+  unless RUBY_PLATFORM == "opal"
+  	Volt.current_app.on("user_connect") do |user_id|
+  		begin
+  			Volt.current_app.store.users.where(id: user_id).first.sync._event_triggered = "user_connect"
+  		rescue
+  			#we rescue as this callback will also get called from the SocketConnectionHandler specs (and will fail)
+  		end
+  	end
+
+  	Volt.current_app.on("user_disconnect") do |user_id|
+  		begin
+  			Volt.current_app.store.users.where(id: user_id).first.sync._event_triggered = "user_disconnect"
+  		rescue
+  			#we rescue as this callback will also get called from the SocketConnectionHandler specs (and will fail)
+  		end
+  	end
+  end
 end

--- a/spec/apps/kitchen_sink/app/main/views/main/callbacks.html
+++ b/spec/apps/kitchen_sink/app/main/views/main/callbacks.html
@@ -1,0 +1,7 @@
+<:Title>
+  Lifecycle Callbacks
+
+<:Body>
+  <h1>Lifecycle Callbacks</h1>
+
+  {{ store.users.first._event_triggered }}

--- a/spec/integration/callbacks_spec.rb
+++ b/spec/integration/callbacks_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'lifecycle callbacks', type: :feature, sauce: true do
+
+	context 'with a user' do
+		before do
+		    # Add the user
+		    store._users! << { email: 'test@test.com', password: 'awes0mesEcRet', name: 'Test Account 9550' }
+		end
+
+		it 'should trigger a user_connect event when a user logs in and a user_disconnect event when a user logs out' do
+			visit '/'
+
+			click_link 'Login'
+
+			fields = all(:css, 'form .form-control')
+			fields[0].set('test@test.com')
+			fields[1].set('awes0mesEcRet')
+			click_button 'Login'
+
+			visit '/callbacks'
+
+			expect(page).to have_content('user_connect')
+
+			click_link 'Test Account 9550'
+			click_link 'Logout'
+
+			expect(page).to have_content('user_disconnect')
+		end
+	end
+end

--- a/spec/server/socket_connection_handler_spec.rb
+++ b/spec/server/socket_connection_handler_spec.rb
@@ -65,7 +65,6 @@ if RUBY_PLATFORM != 'opal'
     describe '#close' do
       it 'should trigger a client_disconnect event' do
         allow(Volt::SocketConnectionHandler.dispatcher).to receive(:close_channel).and_return true
-        allow(Volt::SocketConnectionHandler.dispatcher).to receive(:respond_to).and_return true
 
         val = 0
 
@@ -78,7 +77,6 @@ if RUBY_PLATFORM != 'opal'
       context 'with valid user_id' do
         it 'should trigger a user_disconnect event' do
           allow(Volt::SocketConnectionHandler.dispatcher).to receive(:close_channel).and_return true
-          allow(Volt::SocketConnectionHandler.dispatcher).to receive(:respond_to).and_return true
 
           subject.user_id = 123
 

--- a/spec/server/socket_connection_handler_spec.rb
+++ b/spec/server/socket_connection_handler_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+if RUBY_PLATFORM != 'opal'
+  require 'volt/server/socket_connection_handler'
+  describe Volt::SocketConnectionHandler do
+    let(:fake_dispatcher) { double("Dispatcher", volt_app: Volt.current_app)}
+
+    let(:fake_session) {double("Faye::WebSocket")}
+
+    before do
+      Volt::SocketConnectionHandler.dispatcher = fake_dispatcher
+    end
+
+    let(:connection_handler) { Volt::SocketConnectionHandler.new(fake_session) }
+
+    subject!{ connection_handler }
+
+    describe '#creation' do
+
+      context 'with valid session' do
+
+        it 'should append itself to @@channels' do
+          expect(Volt::SocketConnectionHandler.channels).to include(subject)
+        end
+
+        it 'should trigger a client_connect event' do
+          val = 0
+
+          Volt.current_app.on("client_connect") do
+            val = 1
+          end
+
+          # TODO: change the way this is handled, we shouldn't have to instantiate a new SocketConnectionHandler just for this test
+          expect{Volt::SocketConnectionHandler.new(fake_session)}.to change{val}.by(1)
+        end
+      end
+    end
+
+    describe '#update' do
+      context 'with nil user_id' do
+        it 'should trigger a user_connect event when given a valid user_id' do
+          id = 0
+          Volt.current_app.on("user_connect") do |user_id|
+            id = user_id
+          end
+
+          expect{subject.update_user_id(123)}.to change{id}.by(123)
+        end
+      end
+
+      context 'with valid user_id' do
+        it 'should trigger a user_disconnect event when given a nil user_id' do
+          id = 0
+          Volt.current_app.on("user_disconnect") do |user_id|
+            id = user_id
+          end
+
+          subject.user_id = 123
+
+          expect{subject.update_user_id(nil)}.to change{id}.by(123)
+        end
+      end
+    end
+
+    describe '#close' do
+      it 'should trigger a client_disconnect event' do
+        allow(Volt::SocketConnectionHandler.dispatcher).to receive(:close_channel).and_return true
+
+        val = 0
+
+        Volt.current_app.on("client_disconnect") do
+          val = 1
+        end
+
+        expect{subject.closed}.to change{val}.by(1)
+      end
+      context 'with valid user_id' do
+        it 'should trigger a user_disconnect event' do
+          allow(Volt::SocketConnectionHandler.dispatcher).to receive(:close_channel).and_return true
+
+          subject.user_id = 123
+
+          id = 0
+
+          Volt.current_app.on("user_disconnect") do |user_id|
+            id = user_id
+          end
+
+          expect{subject.closed}.to change{id}.by(123)
+        end
+      end
+    end
+  end
+end

--- a/spec/server/socket_connection_handler_spec.rb
+++ b/spec/server/socket_connection_handler_spec.rb
@@ -65,6 +65,7 @@ if RUBY_PLATFORM != 'opal'
     describe '#close' do
       it 'should trigger a client_disconnect event' do
         allow(Volt::SocketConnectionHandler.dispatcher).to receive(:close_channel).and_return true
+        allow(Volt::SocketConnectionHandler.dispatcher).to receive(:respond_to).and_return true
 
         val = 0
 
@@ -77,6 +78,7 @@ if RUBY_PLATFORM != 'opal'
       context 'with valid user_id' do
         it 'should trigger a user_disconnect event' do
           allow(Volt::SocketConnectionHandler.dispatcher).to receive(:close_channel).and_return true
+          allow(Volt::SocketConnectionHandler.dispatcher).to receive(:respond_to).and_return true
 
           subject.user_id = 123
 


### PR DESCRIPTION
Currently the only events are 'user_connect' and 'user_disconnect' which are triggered serverside whenever the user logs in or logs out. These events also trigger when the user navigates to the app with a valid session cookie or closes the window.

These events can trigger a block to run by adding the following code to a volt app:

```
Volt.current_app.on("user_connect") do |user_id|
# fetch user
end

Volt.current_app.on("user_disconnect") do |user_id|
# fetch user
end
```
