### PR TITLE
[DO NOT MERGE] Verify buggy dispatch tests

### DIFF
--- a/spec/tasks/dispatcher_spec.rb
+++ b/spec/tasks/dispatcher_spec.rb
@@ -67,7 +67,12 @@ if RUBY_PLATFORM != 'opal'
     it 'should log an info message before and after the dispatch' do
       channel = double('channel')
 
+      # NOTE: This method stub is incorrect. We should be stubbing #send_string_message
+      #  See line 150 in lib/volt/tasks/dispatcher.rb
       allow(channel).to receive(:send_message).with('response', 0, 'yes it works', nil)
+
+      # NOTE: This is what I think the stub needs to be.
+      #allow(channel).to receive(:send_string_message).with(any_args)
       expect(Volt.logger).to receive(:log_dispatch)
 
       dispatcher.dispatch(channel, [0, 'TestTask', :allowed_method, {}, ' it', ' works'])
@@ -76,7 +81,12 @@ if RUBY_PLATFORM != 'opal'
     it 'should let you set a cookie' do
       channel = double('channel')
 
+      # NOTE: This method stub is incorrect. We should be stubbing #send_string_message
+      #  See line 150 in lib/volt/tasks/dispatcher.rb
       allow(channel).to receive(:send_message).with('response', 0, 'yes it works', {something:"awesome"})
+
+      # NOTE: This is what I think the stub needs to be.
+      #allow(channel).to receive(:send_string_message).with(any_args)
       expect(Volt.logger).to receive(:log_dispatch)
 
       dispatcher.dispatch(channel, [0, 'TestTask', :set_cookie, {}])


### PR DESCRIPTION
## DO NOT MERGE

I believe I have found two buggy dispatcher tests. These tests create method stubs that are never called. When a different method is called on the test double an error is raised. However, the unstubbed method call happens inside a `Promise` and so the error is suppressed. Instead of the test failing the promise's `fail` block runs. I discovered this while working on a spike of [this](https://github.com/voltrb/volt/issues/310#issuecomment-144799960) potential dispatcher update.

This PR does *not* change the tests. Since I am new to both Volt and Opal I wanted to get verification from someone more knowledgeable. If what I believe is happening is correct I will be happy to update the PR.