### PR TITLE
Middle ware to parse application/json http requests

### DIFF
--- a/lib/volt/server/middleware/default_middleware_stack.rb
+++ b/lib/volt/server/middleware/default_middleware_stack.rb
@@ -7,6 +7,7 @@ require 'volt/server/rack/opal_files'
 require 'volt/server/rack/index_files'
 require 'volt/server/rack/http_resource'
 require 'volt/server/rack/sprockets_helpers_setup'
+require 'volt/server/rack/http_content_types'
 
 
 
@@ -24,6 +25,7 @@ module Volt
       rack_app.use Rack::KeepAlive
       rack_app.use Rack::ConditionalGet
       rack_app.use Rack::ETag
+      rack_app.use Rack::HttpContentTypes
 
       rack_app.use Rack::Session::Cookie, {
         key: 'rack.session',

--- a/lib/volt/server/rack/http_content_types.rb
+++ b/lib/volt/server/rack/http_content_types.rb
@@ -1,0 +1,62 @@
+# Middleware for parsing params of different restful content in HTTP endpoints.
+# Content-type: application/json - is supported out of the box
+#
+# Much thanks to @achiu (https://github.com/achiu) for original version of this middleware
+#
+# New Parsers can be added in your app's config:
+#      Volt.setup do |config|
+#        config.http_content_types = {
+#          parsers: {
+#            'application/roll' => proc { |body| {'rick_says' => 'never gonna give you up'}}
+#          }
+#        }
+#      end
+
+module Rack
+  class HttpContentTypes
+
+    POST_BODY  = 'rack.input'.freeze
+    FORM_INPUT = 'rack.request.form_input'.freeze
+    FORM_HASH  = 'rack.request.form_hash'.freeze
+
+    JSON_PARSER   = proc { |data| JSON.parse data }
+    ERROR_HANDLER = proc { |err, type| [400, {}, ['']] }
+
+    attr_reader :parsers, :handlers, :logger
+
+    def initialize(app, options = {})
+      @app = app
+      @options = Volt.config.http_content_types.dup || {}
+      @options.merge!(options)
+      @parsers = @options[:parsers] || {}
+      @handlers = @options[:handlers] || {}
+      unless parsers.detect { |content_type, _| 'json'.match(content_type) }
+        @parsers.merge!({ %r{json} => JSON_PARSER })
+      end
+    end
+
+    def call(env)
+      type   = Rack::Request.new(env).media_type
+      parser = parsers.detect { |content_type, _| type.match(content_type) } if type
+      return @app.call(env) unless parser
+      body = env[POST_BODY].read ; env[POST_BODY].rewind
+      return @app.call(env) unless body && !body.empty?
+      begin
+        parsed = parser.last.call body
+        env.update FORM_HASH => parsed, FORM_INPUT => env[POST_BODY]
+      rescue StandardError => e
+        warn! e, type
+        handler   = handlers.detect { |content_type, _|  type.match(content_type) }
+        handler ||= ['default', ERROR_HANDLER]
+        return handler.last.call(e, type)
+      end
+      @app.call env
+    end
+
+    def warn!(error, content_type)
+      return unless Volt.logger
+      message = "[Rack::HttpContentType] Error on %s : %s" % [content_type, error.to_s]
+      Volt.logger.warn message
+    end
+  end
+end

--- a/lib/volt/server/rack/http_content_types.rb
+++ b/lib/volt/server/rack/http_content_types.rb
@@ -26,7 +26,7 @@ module Rack
 
     def initialize(app, options = {})
       @app = app
-      @options = Volt.config.http_content_types.dup || {}
+      @options = Volt.config.http_content_types ? Volt.config.http_content_types.dup : {}
       @options.merge!(options)
       @parsers = @options[:parsers] || {}
       @handlers = @options[:handlers] || {}

--- a/spec/apps/kitchen_sink/app/main/config/routes.rb
+++ b/spec/apps/kitchen_sink/app/main/config/routes.rb
@@ -29,6 +29,7 @@ client '/login', component: 'user_templates', controller: 'login'
 get '/simple_http', controller: 'simple_http', action: 'index'
 get '/simple_http/store', controller: 'simple_http', action: 'show'
 post '/simple_http/upload', controller: 'simple_http', action: 'upload'
+post '/simple_http', controller: 'simple_http', action: 'create'
 
 # Route for file uploads
 client '/upload', controller: 'upload', action: 'index'

--- a/spec/apps/kitchen_sink/app/main/controllers/server/simple_http_controller.rb
+++ b/spec/apps/kitchen_sink/app/main/controllers/server/simple_http_controller.rb
@@ -8,6 +8,10 @@ module Main
       render text: "You had me at #{store._simple_http_tests.first._name.sync}"
     end
 
+    def create
+      render text: params.inspect
+    end
+
     def upload
       uploaded = params._file._tempfile
       File.open('tmp/uploaded_file', 'wb') { |f| f.write(uploaded.read) }

--- a/spec/server/middleware/rack_content_types_spec.rb
+++ b/spec/server/middleware/rack_content_types_spec.rb
@@ -6,67 +6,73 @@ if RUBY_PLATFORM != 'opal'
 
     let(:app) { Volt.current_app.middleware }
 
-    before do
-      Volt.setup do |config|
-        config.http_content_types = {
-          parsers: {
-            'application/roll' => proc { |body| {'rick_says' => 'never gonna give you up'}}
+    describe 'with default parser' do
+      it "allows you to setup parsers for content types" do
+        middleware = Rack::HttpContentTypes.new Volt, :parsers => { 'foo' => 'bar' } 
+        expect(middleware.parsers['foo']).to eq('bar')
+      end
+
+      it "allows you to setup error handlers" do
+        middleware = Rack::HttpContentTypes.new Volt, :handlers => { 'foo' => 'bar' } 
+        expect(middleware.handlers['foo']).to eq('bar')
+      end
+
+      it "parses params from Content-Type: application/json" do
+        payload = JSON.dump(:a => 1)
+        post '/simple_http', payload, { 'CONTENT_TYPE' => 'application/json' }
+        expect(last_response).to be_ok
+        expect(last_response.body).to match(/a: 1/)
+      end
+
+      it "does not handle params from unknown Content-type" do
+        payload = JSON.dump(:a => 1)
+        post '/simple_http', payload, { 'CONTENT_TYPE' => 'application/unknown' }
+        expect(last_response).to be_ok
+        expect(last_response.body).to_not match(/a: 1/)
+      end
+
+      it "matches Content-Type by regex" do
+        payload = JSON.dump(:a => 1)
+        post '/simple_http', payload, { 'CONTENT_TYPE' => 'application/vnd.foo+json' }
+        expect(last_response).to be_ok
+        expect(last_response.body).to match(/a: 1/)
+      end
+
+      it "handles custom json parser" do
+        Volt.setup do |config|
+          config.http_content_types = {
+            parsers:{
+              'application/json' => proc { |body| {'rick_says' => 'never gonna let you down'} }
+            }
           }
-        }
+        end
+        payload = JSON.dump(:a => 1)
+        post '/simple_http', payload, { 'CONTENT_TYPE' => 'application/json' }
+        expect(last_response).to be_ok
+        expect(last_response.body).to match(/never gonna let you down/)
       end
     end
 
-    it "allows you to setup parsers for content types" do
-      middleware = Rack::HttpContentTypes.new Volt, :parsers => { 'foo' => 'bar' } 
-      expect(middleware.parsers['foo']).to eq('bar')
-    end
-
-    it "allows you to setup error handlers" do
-      middleware = Rack::HttpContentTypes.new Volt, :handlers => { 'foo' => 'bar' } 
-      expect(middleware.handlers['foo']).to eq('bar')
-    end
-
-    it "parses params from Content-Type: application/json" do
-      payload = JSON.dump(:a => 1)
-      post '/simple_http', payload, { 'CONTENT_TYPE' => 'application/json' }
-      expect(last_response).to be_ok
-      expect(last_response.body).to match(/a: 1/)
-    end
-
-    it "does not handle params from unknown Content-type" do
-      payload = JSON.dump(:a => 1)
-      post '/simple_http', payload, { 'CONTENT_TYPE' => 'application/unknown' }
-      expect(last_response).to be_ok
-      expect(last_response.body).to_not match(/a: 1/)
-    end
-
-    it "matches Content-Type by regex" do
-      payload = JSON.dump(:a => 1)
-      post '/simple_http', payload, { 'CONTENT_TYPE' => 'application/vnd.foo+json' }
-      expect(last_response).to be_ok
-      expect(last_response.body).to match(/a: 1/)
-    end
-
-    it "handles custom content types" do
-      #see spec/apps/kitchen_sink/config/app.rb
-      payload = JSON.dump(:a => 1)
-      post '/simple_http', payload, { 'CONTENT_TYPE' => 'application/roll' }
-      expect(last_response).to be_ok
-      expect(last_response.body).to match(/never gonna give you up/)
-    end
-
-    it "handles custom json parser" do
-      Volt.setup do |config|
-        config.http_content_types = {
-          parsers:{
-            'application/json' => proc { |body| {'rick_says' => 'never gonna let you down'} }
+    describe 'with custom parser' do
+      before do
+        Volt.setup do |config|
+          config.http_content_types = {
+            parsers: {
+              'application/roll' => proc { |body| {'rick_says' => 'never gonna give you up'}}
+            }
           }
-        }
+        end
       end
-      payload = JSON.dump(:a => 1)
-      post '/simple_http', payload, { 'CONTENT_TYPE' => 'application/json' }
-      expect(last_response).to be_ok
-      expect(last_response.body).to match(/never gonna let you down/)
+
+      it "handles custom content types" do
+        #see spec/apps/kitchen_sink/config/app.rb
+        payload = JSON.dump(:a => 1)
+        post '/simple_http', payload, { 'CONTENT_TYPE' => 'application/roll' }
+        expect(last_response).to be_ok
+        expect(last_response.body).to match(/never gonna give you up/)
+      end
     end
+
+
   end
 end

--- a/spec/server/middleware/rack_content_types_spec.rb
+++ b/spec/server/middleware/rack_content_types_spec.rb
@@ -1,0 +1,72 @@
+if RUBY_PLATFORM != 'opal'
+  require 'spec_helper'
+
+  describe Rack::HttpContentTypes do
+    include Rack::Test::Methods
+
+    let(:app) { Volt.current_app.middleware }
+
+    before do
+      Volt.setup do |config|
+        config.http_content_types = {
+          parsers: {
+            'application/roll' => proc { |body| {'rick_says' => 'never gonna give you up'}}
+          }
+        }
+      end
+    end
+
+    it "allows you to setup parsers for content types" do
+      middleware = Rack::HttpContentTypes.new Volt, :parsers => { 'foo' => 'bar' } 
+      expect(middleware.parsers['foo']).to eq('bar')
+    end
+
+    it "allows you to setup error handlers" do
+      middleware = Rack::HttpContentTypes.new Volt, :handlers => { 'foo' => 'bar' } 
+      expect(middleware.handlers['foo']).to eq('bar')
+    end
+
+    it "parses params from Content-Type: application/json" do
+      payload = JSON.dump(:a => 1)
+      post '/simple_http', payload, { 'CONTENT_TYPE' => 'application/json' }
+      expect(last_response).to be_ok
+      expect(last_response.body).to match(/a: 1/)
+    end
+
+    it "does not handle params from unknown Content-type" do
+      payload = JSON.dump(:a => 1)
+      post '/simple_http', payload, { 'CONTENT_TYPE' => 'application/unknown' }
+      expect(last_response).to be_ok
+      expect(last_response.body).to_not match(/a: 1/)
+    end
+
+    it "matches Content-Type by regex" do
+      payload = JSON.dump(:a => 1)
+      post '/simple_http', payload, { 'CONTENT_TYPE' => 'application/vnd.foo+json' }
+      expect(last_response).to be_ok
+      expect(last_response.body).to match(/a: 1/)
+    end
+
+    it "handles custom content types" do
+      #see spec/apps/kitchen_sink/config/app.rb
+      payload = JSON.dump(:a => 1)
+      post '/simple_http', payload, { 'CONTENT_TYPE' => 'application/roll' }
+      expect(last_response).to be_ok
+      expect(last_response.body).to match(/never gonna give you up/)
+    end
+
+    it "handles custom json parser" do
+      Volt.setup do |config|
+        config.http_content_types = {
+          parsers:{
+            'application/json' => proc { |body| {'rick_says' => 'never gonna let you down'} }
+          }
+        }
+      end
+      payload = JSON.dump(:a => 1)
+      post '/simple_http', payload, { 'CONTENT_TYPE' => 'application/json' }
+      expect(last_response).to be_ok
+      expect(last_response.body).to match(/never gonna let you down/)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,9 @@
 
 require 'volt/spec/setup'
-require 'rack/test'
 
 unless RUBY_PLATFORM == 'opal'
   begin
+    require 'rack/test'
     require 'pry-byebug'
   rescue LoadError => e
     # Ignore if not installed

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 
 require 'volt/spec/setup'
+require 'rack/test'
 
 unless RUBY_PLATFORM == 'opal'
   begin


### PR DESCRIPTION
## Rack Middleware to handle different content for the http routes
API communication with mobile applications uses various formats specified by their 'Content-type' header, including JSON, and XML.  This PR adds support for JSON, and makes other parsers pluggable.  The parsers are needed to transform the body of POST requests into params attributes that can be consumed by the Volt controllers. 

## About
- Handles 'application/json' by default
- enables Volt.config.http_content_types setting to add additional parsers
- handles nested attributes gracefully