### PR TITLE
Updates for mongo 2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ end
 
 group :development, :test do
   platform :mri do
-    gem 'bson_ext'
 
     # For running tests
     gem 'thin'

--- a/lib/volt/store/mongo.rb
+++ b/lib/volt/store/mongo.rb
@@ -1,5 +1,0 @@
-require 'mongo'
-
-mongo_client = Mongo::MongoClient.new('localhost', 27_017)
-
-db = mongo_client.db('test1')

--- a/spec/apps/kitchen_sink/Gemfile
+++ b/spec/apps/kitchen_sink/Gemfile
@@ -51,5 +51,4 @@ platform :mri do
   # Thin is the default volt server, you Puma is also supported
   gem 'thin', '~> 1.6.0'
   # gem 'puma'
-  gem 'bson_ext', '~> 1.9.0'
 end

--- a/spec/apps/kitchen_sink/app/main/models/post.rb
+++ b/spec/apps/kitchen_sink/app/main/models/post.rb
@@ -2,4 +2,5 @@ class Post < Volt::Model
   field :title, String
 
   validate :title, length: 5
+
 end

--- a/spec/store/mongo_spec.rb
+++ b/spec/store/mongo_spec.rb
@@ -1,7 +1,0 @@
-# require 'mongo'
-# include Mongo
-#
-# mongo_client = MongoClient.new("localhost", 27017)
-# items = mongo_client['docs']['items']
-#
-# items


### PR DESCRIPTION
* Remove bson_ext gem (C extensions included by BSON gem 3.x)
* Remove remnants of volt-mongo

All tests passing with mongo 2.1.2; however, note that Travis is going to run them for this PR with mongo 1.12 since volt-mongo hasn't been republished yet.