### PR TITLE
Fix operator precedence bug that causes anyone to view all users.

### DIFF
--- a/app/volt/models/user.rb
+++ b/app/volt/models/user.rb
@@ -18,7 +18,7 @@ module Volt
       deny :hashed_password
 
       # Deny all if this isn't the owner
-      deny if !id == Volt.current_user_id && !new?
+      deny if id != Volt.current_user_id && !new?
     end
 
     unless RUBY_PLATFORM == 'opal'


### PR DESCRIPTION
I honestly don't know how to create working specs for this one @_@  But the issue is illustrated below.

```
volt> Volt.current_user
=> #<Promise(1358): nil>
volt> store._users.all.each do |u| 
...    puts u.inspect 
...    end
=> #<Promise(1518)>
#<User id: "518c..5204", email: "bob@gmail.com">
#<User id: "4f9f..c796", email: "al@gmail.com">
```