### PR TITLE
Delete unused queries from @volt_app.channel_live_queries

### DIFF
--- a/app/volt/tasks/live_query/live_query.rb
+++ b/app/volt/tasks/live_query/live_query.rb
@@ -3,7 +3,7 @@ require_relative 'query_tracker'
 # Tracks a channel and a query on a collection.  Alerts
 # the listener when the data in the query changes.
 class LiveQuery
-  attr_reader :current_ids, :collection, :query
+  attr_reader :current_ids, :collection, :query, :channels
 
   def initialize(pool, data_store, collection, query)
     @pool = pool

--- a/app/volt/tasks/query_tasks.rb
+++ b/app/volt/tasks/query_tasks.rb
@@ -47,7 +47,7 @@ class QueryTasks < Volt::Task
     live_query.remove_channel(@channel)
 
     # If query has no more channels remove it from channel_live_queries
-    # @volt_app.channel_live_queries[@channel].delete(live_query) if live_query.channels.blank?
+    @volt_app.channel_live_queries[@channel].delete_if{|channel_live_query| channel_live_query.channels.blank? }
   end
 
   # Removes a channel from all associated live queries

--- a/app/volt/tasks/query_tasks.rb
+++ b/app/volt/tasks/query_tasks.rb
@@ -47,7 +47,8 @@ class QueryTasks < Volt::Task
     live_query.remove_channel(@channel)
 
     # If query has no more channels remove it from channel_live_queries
-    @volt_app.channel_live_queries[@channel].delete_if{|channel_live_query| channel_live_query.channels.blank? }
+    @volt_app.channel_live_queries[@channel].delete(live_query) if live_query.channels.blank? unless RUBY_PLATFORM == 'opal'
+    return true
   end
 
   # Removes a channel from all associated live queries

--- a/app/volt/tasks/query_tasks.rb
+++ b/app/volt/tasks/query_tasks.rb
@@ -47,7 +47,7 @@ class QueryTasks < Volt::Task
     live_query.remove_channel(@channel)
 
     # If query has no more channels remove it from channel_live_queries
-    @volt_app.channel_live_queries[@channel].delete(live_query) if live_query.channels.blank? unless RUBY_PLATFORM == 'opal'
+    @volt_app.channel_live_queries[@channel].delete(live_query) if live_query.channels.blank?
     return true
   end
 

--- a/app/volt/tasks/query_tasks.rb
+++ b/app/volt/tasks/query_tasks.rb
@@ -47,7 +47,7 @@ class QueryTasks < Volt::Task
     live_query.remove_channel(@channel)
 
     # If query has no more channels remove it from channel_live_queries
-    @volt_app.channel_live_queries[@channel].delete(live_query) if live_query.channels.blank?
+    # @volt_app.channel_live_queries[@channel].delete(live_query) if live_query.channels.blank?
   end
 
   # Removes a channel from all associated live queries

--- a/app/volt/tasks/query_tasks.rb
+++ b/app/volt/tasks/query_tasks.rb
@@ -45,6 +45,9 @@ class QueryTasks < Volt::Task
   def remove_listener(collection, query)
     live_query = @volt_app.live_query_pool.lookup(collection, query)
     live_query.remove_channel(@channel)
+
+    # If query has no more channels remove it from channel_live_queries
+    @volt_app.channel_live_queries[@channel].delete(live_query) if live_query.channels.blank?
   end
 
   # Removes a channel from all associated live queries


### PR DESCRIPTION
Unused queries and duplicates were building up in @volt_app.channel_live_queries.  This was leaving the LiveQuery objects in memory and possibly having their QueryTracker remain active.  This is a small change to remove unused queries from @volt_app.channel_live_queries.
